### PR TITLE
Add PR validation to build pipeline (full pipeline, no duplication)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,7 +1,14 @@
 name: Build & Release
 
 on:
-  workflow_dispatch:  # Manual trigger only (version-check.yml notifies of new versions)
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  workflow_dispatch:  # Manual trigger for releases (version-check.yml notifies of new versions)
     inputs:
       download_url:
         description: 'Manual download URL (optional - bypasses auto-detection if Cloudflare blocks)'
@@ -13,6 +20,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 # ──────────────────────────────────────────────────────────────────────
 # Job graph (fan-out / fan-in):
 #
@@ -22,11 +33,14 @@ on:
 #                                     ├── test-nix
 #                                     └── generate-pkgbuild ──► test-pkgbuild (makepkg + namcap)
 #                                              │
-#                                     release (needs all above, assembles APT repo)
+#                                     release (needs all above — workflow_dispatch only)
 #                                              │
-#                                     deploy-rpm-repo (fedora:40, signs RPMs, uploads Pages artifact)
+#                                     deploy-rpm-repo (fedora:40, signs RPMs — workflow_dispatch only)
 #                                              │
-#                                     deploy-pages (deploys to GitHub Pages)
+#                                     deploy-pages (deploys to GitHub Pages — workflow_dispatch only)
+#
+# On pull_request: all validation jobs run, release/deploy jobs are skipped.
+# On workflow_dispatch: full pipeline including release and deploy.
 # ──────────────────────────────────────────────────────────────────────
 
 jobs:
@@ -39,10 +53,10 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       needs_update: ${{ steps.check.outputs.needs_update }}
       highest_version: ${{ steps.check.outputs.highest_version }}
-      pkgrel: ${{ steps.pkgrel.outputs.pkgrel }}
-      tag: ${{ steps.pkgrel.outputs.tag }}
-      release_name: ${{ steps.pkgrel.outputs.release_name }}
-      make_latest: ${{ steps.pkgrel.outputs.make_latest }}
+      pkgrel: ${{ steps.pkgrel.outputs.pkgrel || steps.pr-defaults.outputs.pkgrel || '1' }}
+      tag: ${{ steps.pkgrel.outputs.tag || steps.pr-defaults.outputs.tag }}
+      release_name: ${{ steps.pkgrel.outputs.release_name || steps.pr-defaults.outputs.release_name }}
+      make_latest: ${{ steps.pkgrel.outputs.make_latest || steps.pr-defaults.outputs.make_latest }}
       changelog: ${{ steps.git_changelog.outputs.content }}
       should_build: ${{ steps.decide.outputs.should_build }}
     steps:
@@ -212,11 +226,22 @@ jobs:
       - name: Decide if build should proceed
         id: decide
         run: |
-          if [ "${{ steps.check.outputs.needs_update }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" == "pull_request" ] || \
+             [ "${{ steps.check.outputs.needs_update }}" == "true" ] || \
+             [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             echo "should_build=true" >> $GITHUB_OUTPUT
           else
             echo "should_build=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set defaults for PR builds
+        id: pr-defaults
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "pkgrel=1" >> $GITHUB_OUTPUT
+          echo "tag=v${{ steps.version.outputs.version }}-pr" >> $GITHUB_OUTPUT
+          echo "release_name=PR Validation" >> $GITHUB_OUTPUT
+          echo "make_latest=false" >> $GITHUB_OUTPUT
 
       - name: Upload exe for build job
         if: steps.decide.outputs.should_build == 'true'
@@ -1161,7 +1186,7 @@ jobs:
   # ================================================================
   release:
     needs: [check-version, build-tarball, build-aarch64-tarball, lint-scripts, package-appimage, package-deb, package-rpm, test-nix, generate-pkgbuild, test-pkgbuild]
-    if: needs.check-version.outputs.should_build == 'true'
+    if: needs.check-version.outputs.should_build == 'true' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1593,7 +1618,7 @@ jobs:
   # ================================================================
   deploy-rpm-repo:
     needs: [check-version, release]
-    if: needs.check-version.outputs.should_build == 'true'
+    if: needs.check-version.outputs.should_build == 'true' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     container: fedora:40
     permissions:
@@ -1662,6 +1687,7 @@ jobs:
   # ================================================================
   deploy-pages:
     needs: [deploy-rpm-repo]
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       pages: write
@@ -1679,7 +1705,7 @@ jobs:
   # ================================================================
   validate-nix:
     needs: [check-version, release]
-    if: needs.check-version.outputs.should_build == 'true'
+    if: needs.check-version.outputs.should_build == 'true' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (latest master with updated hash)

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -328,8 +328,23 @@ jobs:
         with:
           name: claude-setup-exe
 
+      - name: Get kwin-portal-bridge repo HEAD
+        id: bridge-rev
+        run: |
+          BRIDGE_SHA=$(git ls-remote https://github.com/patrickjaja/kwin-portal-bridge.git HEAD | cut -f1)
+          echo "sha=${BRIDGE_SHA}" >> $GITHUB_OUTPUT
+          echo "kwin-portal-bridge HEAD: ${BRIDGE_SHA}"
+
+      - name: Cache kwin-portal-bridge binaries
+        id: bridge-cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/bridge-output
+          key: kwin-portal-bridge-${{ steps.bridge-rev.outputs.sha }}
+
       - name: Build kwin-portal-bridge (x86_64 + aarch64, glibc 2.31 target)
         id: bridge
+        if: steps.bridge-cache.outputs.cache-hit != 'true'
         run: |
           echo "=== Building kwin-portal-bridge (Trixie PipeWire 1.4, glibc 2.31 via zigbuild) ==="
           mkdir -p /tmp/bridge-output
@@ -371,6 +386,8 @@ jobs:
               echo 'kwin-portal-bridge aarch64 built successfully'
             "
 
+      - name: Verify kwin-portal-bridge binaries
+        run: |
           echo "--- x86_64 binary ---"
           file /tmp/bridge-output/kwin-portal-bridge
           GLIBC_MAX=$(objdump -T /tmp/bridge-output/kwin-portal-bridge 2>/dev/null | grep -oP 'GLIBC_\S+' | sort -uV | tail -1 || echo "unknown")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 All notable changes to claude-desktop-bin AUR package will be documented in this file.
 
-## 2026-05-05 — CI: add PR validation (full pipeline for contributors)
+## 2026-05-05 — CI: add PR validation + kwin-portal-bridge cache
 
 - **Added:** `pull_request` trigger on `build-and-release.yml` — contributors now get the full build pipeline on PRs (patches, kwin-portal-bridge, all packaging formats, glibc verification, both architectures)
 - **Added:** Concurrency control — pushing new commits to a PR cancels in-progress CI runs
 - **Added:** `paths-ignore` — docs-only PRs skip the pipeline
 - **Changed:** Release-only jobs (`release`, `deploy-rpm-repo`, `deploy-pages`, `validate-nix`) gated with `github.event_name == 'workflow_dispatch'` — skipped on PRs, no code duplication
+- **Optimized:** Cache kwin-portal-bridge binaries keyed on upstream repo HEAD SHA — skips the ~13min Rust build on cache hit, glibc verification still runs every time
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to claude-desktop-bin AUR package will be documented in this file.
 
+## 2026-05-05 — CI: add PR validation (full pipeline for contributors)
+
+- **Added:** `pull_request` trigger on `build-and-release.yml` — contributors now get the full build pipeline on PRs (patches, kwin-portal-bridge, all packaging formats, glibc verification, both architectures)
+- **Added:** Concurrency control — pushing new commits to a PR cancels in-progress CI runs
+- **Added:** `paths-ignore` — docs-only PRs skip the pipeline
+- **Changed:** Release-only jobs (`release`, `deploy-rpm-repo`, `deploy-pages`, `validate-nix`) gated with `github.event_name == 'workflow_dispatch'` — skipped on PRs, no code duplication
+
+---
+
 ## 2026-05-04 — AUR: add aarch64 architecture support
 
 - **Added:** `PKGBUILD.template` now declares `arch=('x86_64' 'aarch64')` with arch-specific source arrays and Electron downloads


### PR DESCRIPTION
Enable the full build-and-release pipeline on pull requests so contributors get CI feedback on patches, packaging, and glibc compliance across all supported distros and architectures.

Changes:
- Add pull_request trigger with paths-ignore for docs
- Add concurrency control (cancel in-progress on new push)
- Add PR defaults for pkgrel/tag (coalesced outputs)
- Gate release-only jobs with github.event_name == 'workflow_dispatch' (release, deploy-rpm-repo, deploy-pages, validate-nix)

Zero job duplication — single source of truth.