### PR TITLE
packaging: recommend sqlite3 (fixes detectedProjects ENOENT spam)

### DIFF
--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -12,6 +12,7 @@ license=('custom:Claude')
 depends=('alsa-lib' 'gtk3' 'nss')
 makedepends=('unzip')
 optdepends=('nodejs: System Node.js for MCP extensions that require specific versions (Electron bundles Node.js as fallback)'
+            'sqlite: Project detection (detectedProjects) — without it, periodic ENOENT errors spam logs/main.log'
             'claude-code: Claude Code CLI for agentic coding features (npm i -g @anthropic-ai/claude-code)'
             'claude-cowork-service: Enables Cowork VM features on Linux'
             'xdotool: Computer Use input (X11), cursor reading + XWayland fallback (Wayland), Quick Entry positioning'

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -159,7 +159,7 @@ Priority: optional
 Architecture: ${DEB_ARCH}
 Installed-Size: ${INSTALLED_SIZE}
 Depends: libgtk-3-0, libnotify4, libnss3, libxss1, libxtst6, libatspi2.0-0, libdrm2, libgbm1, libasound2
-Recommends: libnotify-bin
+Recommends: libnotify-bin, sqlite3
 Suggests: xdotool, scrot, imagemagick, wmctrl, socat, hyprland, ydotool, grim, jq, libglib2.0-bin, gnome-screenshot, nodejs
 Maintainer: Claude Desktop Linux Community <claude-desktop-linux@users.noreply.github.com>
 Homepage: https://claude.ai

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -10,7 +10,7 @@ Rules-Requires-Root: no
 Package: claude-desktop-bin
 Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, electron | electron-bin | electron33
-Recommends: libnotify-bin
+Recommends: libnotify-bin, sqlite3
 Suggests: xdotool, scrot, imagemagick, wmctrl, socat, hyprland, ydotool, grim, jq, kde-spectacle, libglib2.0-bin, python3-gi, gstreamer1.0-pipewire, gnome-screenshot, nodejs
 Description: Claude AI Desktop Application
  Claude is an AI assistant created by Anthropic to be helpful,

--- a/packaging/rpm/claude-desktop-bin.spec
+++ b/packaging/rpm/claude-desktop-bin.spec
@@ -22,6 +22,10 @@ Requires:       libdrm
 Requires:       mesa-libgbm
 Requires:       alsa-lib
 Requires:       libnotify
+# Project detection (detectedProjects source) — without it, periodic ENOENT
+# errors spam ~/.config/Claude/logs/main.log and detected-projects features
+# don't surface. Soft dep so the app still installs without it.
+Recommends:     sqlite
 # Computer Use — X11/XWayland
 Suggests:       xdotool
 Suggests:       scrot


### PR DESCRIPTION
## Problem

On a fresh `1.6259.1-1` `.deb` install on Ubuntu 25.10, this error shows up in `~/.config/Claude/logs/main.log` every few minutes:

```
[error] [detectedProjects] source failed: Error: Failed to spawn /usr/bin/sqlite3: spawn /usr/bin/sqlite3 ENOENT
    at ChildProcess.<anonymous> (/usr/lib/claude-desktop/resources/app.asar/.vite/build/index.js:489:103901)
    at ChildProcess.emit (node:events:509:28)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
```

The app shells out to `/usr/bin/sqlite3` for the `detectedProjects` data source. The Debian package pulls `libsqlite3-0` transitively via `shlibs:Depends`, but the `sqlite3` CLI is a separate package and isn't declared anywhere — so most installs are missing it.

Reproducer:

```bash
docker run -it --rm ubuntu:25.10 bash -c '
  apt-get update -qq && apt-get install -y -qq curl ca-certificates electron 2>/dev/null
  curl -sLO https://github.com/patrickjaja/claude-desktop-bin/releases/latest/download/claude-desktop-bin_1.6259.1-1_amd64.deb
  dpkg -i claude-desktop-bin_*.deb || apt-get install -fy
  which sqlite3 || echo "MISSING"
'
```

## Fix

Add `sqlite3` (apt) / `sqlite` (rpm/arch) as a soft dependency across the four packagers that ship a runtime deps list:

| File | Change |
|---|---|
| `packaging/debian/build-deb.sh` | `Recommends: libnotify-bin, sqlite3` |
| `packaging/debian/control` | `Recommends: libnotify-bin, sqlite3` |
| `packaging/rpm/claude-desktop-bin.spec` | `Recommends: sqlite` |
| `PKGBUILD.template` | new `sqlite:` line in `optdepends=(...)` |

`Recommends`/`optdepends` (rather than `Depends`/`Requires`) keeps installs working if the user explicitly opts out — the app launches fine without `sqlite3`, the only effect is that detectedProjects features are silently unavailable.

## Testing

- ✅ Verified on Ubuntu 25.10 host: installing the `sqlite3` apt package eliminates the ENOENT error in `main.log` immediately.
- ⚠️ The RPM and Arch changes are mechanical and were **not** built locally. Happy to drop them and scope to Debian only if you'd prefer.

## Not in this PR

- `packaging/nix/package.nix` — needs `sqlite` added to the `makeWrapper` PATH wrap rather than to a deps list. Different shape; left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)