### PR TITLE
Fix patches for Claude Desktop v1.7196.0 (imagine, cowork_first_bash, dispatch)

### DIFF
--- a/patches/fix_cowork_first_bash.nim
+++ b/patches/fix_cowork_first_bash.nim
@@ -16,9 +16,16 @@ proc apply*(input: string): string =
     return result
 
   # Step 1: find the events socket variable name
-  let evSockPat =
+  # v1.6608 shape: function NAME(){if(VAR)return;const X=Y.createConnection
+  # v1.7196 shape: function NAME(){return VAR?Promise.resolve():new Promise((e,A)=>{const X=Y.createConnection
+  let evSockPatOld =
     re"function ([\w$]+)\(\)\{if\(([\w$]+)\)return;const [\w$]+=[\w$]+\.createConnection"
-  let evSockMatch = result.find(evSockPat)
+  let evSockPatNew =
+    re"function ([\w$]+)\(\)\{return ([\w$]+)\?Promise\.resolve\(\):new Promise\(\([\w$]+,[\w$]+\)=>\{const [\w$]+=[\w$]+\.createConnection"
+
+  var evSockMatch = result.find(evSockPatNew)
+  if evSockMatch.isNone:
+    evSockMatch = result.find(evSockPatOld)
   if evSockMatch.isNone:
     echo "  [FAIL] A events socket wait: cannot find events socket function"
     raise newException(

--- a/patches/fix_dispatch_linux.nim
+++ b/patches/fix_dispatch_linux.nim
@@ -150,8 +150,13 @@ proc apply*(input: string): string =
         m.captures[1],
     )
 
+    # v1.6608: function pt(e){const A=Hu[e];return(A==null?void 0:A.on)??!1}
+    # v1.7196: function pt(e){const A=Hu[e];return D8(e,A),(A==null?void 0:A.on)??!1}
+    # The optional non-capturing group (?:[\w$]+\([\w$,]+\),)? matches the
+    # new telemetry call (e.g. "D8(e,A),") that may sit between `return` and
+    # the actual flag check.
     let jrPattern =
-      re"(function )([\w$]+)(\()([\w$]+)(\)\{)(const [\w$]+=[\w$]+\[\4\];return\([\w$]+==null\?void 0:[\w$]+\.on\)\?\?!1\})"
+      re"(function )([\w$]+)(\()([\w$]+)(\)\{)(const [\w$]+=[\w$]+\[\4\];return\s*(?:[\w$]+\([\w$,]+\),)?\([\w$]+==null\?void 0:[\w$]+\.on\)\?\?!1\})"
     var countE = 0
     result = result.replace(
       jrPattern,

--- a/patches/fix_imagine_linux.nim
+++ b/patches/fix_imagine_linux.nim
@@ -33,24 +33,40 @@ proc apply*(input: string): string =
   var patchesApplied = 0
 
   # Patch A: Force isEnabled in visualize server definition
-  let alreadyA = "isEnabled:t=>(true)&&t.sessionType===\"cowork\"" in result
+  # v1.6608: isEnabled:e=>(pt("3444158716")||!1)&&e.sessionType==="cowork"
+  # v1.7196: isEnabled:e=>(pt("3444158716")||!1)&&(e.sessionType==="cowork"||e.sessionType==="ccd"&&pt("2204227020"))
+  let alreadyA =
+    "isEnabled:t=>(true)&&(t.sessionType===\"cowork\"||t.sessionType===\"ccd\")" in result or
+    "isEnabled:t=>(true)&&t.sessionType===\"cowork\"" in result
   if alreadyA:
     echo "  [OK] isEnabled: already patched (skipped)"
     patchesApplied += 1
   else:
-    let patternA =
-      re2"isEnabled:[\w$]+=>\([\w$]+\(""3444158716""\)\|\|!1\)&&[\w$]+\.sessionType===""cowork"""
-
+    # Try v1.7196+ pattern first (cowork || ccd with second flag)
+    let patternANew =
+      re2"isEnabled:[\w$]+=>\([\w$]+\(""3444158716""\)\|\|!1\)&&\([\w$]+\.sessionType===""cowork""\|\|[\w$]+\.sessionType===""ccd""&&[\w$]+\(""\d+""\)\)"
     var countA = result.replaceFirst(
-      patternA,
+      patternANew,
       proc(m: RegexMatch2, s: string): string =
-        "isEnabled:t=>(true)&&t.sessionType===\"cowork\"",
+        "isEnabled:t=>(true)&&(t.sessionType===\"cowork\"||t.sessionType===\"ccd\")",
     )
     if countA >= 1:
-      echo &"  [OK] isEnabled: forced ON for cowork sessions ({countA} match)"
+      echo &"  [OK] isEnabled: forced ON for cowork+ccd sessions ({countA} match, v1.7196+ pattern)"
       patchesApplied += 1
     else:
-      echo "  [FAIL] isEnabled pattern not found"
+      # Fallback: v1.6608 pattern (cowork only)
+      let patternAOld =
+        re2"isEnabled:[\w$]+=>\([\w$]+\(""3444158716""\)\|\|!1\)&&[\w$]+\.sessionType===""cowork"""
+      countA = result.replaceFirst(
+        patternAOld,
+        proc(m: RegexMatch2, s: string): string =
+          "isEnabled:t=>(true)&&t.sessionType===\"cowork\"",
+      )
+      if countA >= 1:
+        echo &"  [OK] isEnabled: forced ON for cowork sessions ({countA} match, v1.6608 pattern)"
+        patchesApplied += 1
+      else:
+        echo "  [FAIL] isEnabled pattern not found"
 
   # Patch B: Force hasImagine variable
   let flagCheck = re2"[\w$]+=[\w$]+\(""3444158716""\)\|\|!1"


### PR DESCRIPTION
## Summary

Three Nim patches stopped matching upstream JS in Claude Desktop **v1.7196.0**. This PR updates the patterns so they recognise the new shapes while keeping the v1.6608 fallbacks for backward compatibility. After applying, `validate-patches.sh` reports 45/46 PASS (the remaining `nim-dir` failure is a pre-existing validator gap unrelated to this release).

Tested end to end with `./scripts/build-fedora-local.sh`, which produced an installable `claude-desktop-bin-1.7196.0-1.x86_64.rpm`.

## Changes

### `patches/fix_imagine_linux.nim`

Upstream extended the `isEnabled` callback of the Visualize MCP server to include a `ccd` session type gated by flag `2204227020`:

```diff
- isEnabled:e=>(pt("3444158716")||!1)&&e.sessionType==="cowork"
+ isEnabled:e=>(pt("3444158716")||!1)&&(e.sessionType==="cowork"||e.sessionType==="ccd"&&pt("2204227020"))
```

The patch now tries the new disjunction pattern first and forces both `cowork` and `ccd` sessions on. Falls back to the original `cowork`-only pattern for older bundles.

### `patches/fix_cowork_first_bash.nim`

The events-socket helper was rewritten from an early-return guard to a Promise-based singleton:

```diff
- function NAME(){if(VAR)return;const t=Y.createConnection(...)
+ function D1e(){return Wm?Promise.resolve():new Promise((e,A)=>{const t=WrA.createConnection(BOA);...})
```

Added a second regex (`function NAME(){return VAR?Promise.resolve():new Promise(...)...createConnection`) which is the only function in the bundle matching that exact shape (the RPC pipe variant has `:Qw||(Qw=new Promise` and doesn't match). Captures the singleton variable (e.g. `Wm`) and feeds it into the existing poll-wait injection unchanged. Falls back to the v1.6608 pattern.

### `patches/fix_dispatch_linux.nim`

Sub-patch E targets the `pt()` flag evaluator. Upstream added a telemetry call before the existing return expression:

```diff
- function pt(e){const A=Hu[e];return(A==null?void 0:A.on)??!1}
+ function pt(e){const A=Hu[e];return D8(e,A),(A==null?void 0:A.on)??!1}
```

Extended the regex with an optional non-capturing telemetry group:

```nim
re"(function )([\w$]+)(\()([\w$]+)(\)\{)(const [\w$]+=[\w$]+\[\4\];return\s*(?:[\w$]+\([\w$,]+\),)?\([\w$]+==null\?void 0:[\w$]+\.on\)\?\?!1\})"
```

Existing capture groups are unchanged, so the replacement that injects the `dispatch ON + hostLoop OFF` short-circuits still works for both with- and without-telemetry shapes. Sub-patches A-D were unaffected and remain untouched.

## Validation

```
$ ./scripts/validate-patches.sh ./tmp/app.asar.contents
...
  Total:   46
  Passed:  45
  Failed:  1     # fix_ion_dist_linux (pre-existing nim-dir validator gap)
```

```
$ patches/fix_imagine_linux /tmp/test.js
  [OK] isEnabled: forced ON for cowork+ccd sessions (1 match, v1.7196+ pattern)
  [OK] hasImagine: forced true (1 match)
  [PASS] Imagine/Visualize enabled for cowork sessions

$ patches/fix_cowork_first_bash /tmp/test.js
  [OK] A events socket wait: injected Wm poll-wait before spawn
  [PASS] First bash command race condition fixed

$ patches/fix_dispatch_linux /tmp/test.js
  [OK] Sessions-bridge gate: forced hVA=!0
  [OK] Remote session control: bypassed (2 matches)
  [OK] Platform label: added Linux to HI()
  [OK] Telemetry gate: included Linux (1 match)
  [OK] Pt() flag overrides: injected dispatch ON + hostLoop OFF (1 match)
  [PASS] 5 patches applied
```

Brace-balance check on the patched bundle still passes (`node --check` runs clean inside the full build).

## Notes for reviewers

- All three patches retain their v1.6608 patterns as explicit fallbacks; no functional behaviour changes for older bundles.
- No new dependencies, no Makefile or wiring changes.
- Tested only against `1.7196.0` (hash `2dbd7802ab037cbb97d77be1a063241009b5e598`) end-to-end via Fedora RPM build. I haven't verified the Arch or Debian builds locally; the patches themselves are shared, so they should work, but a clean CI run on this branch would be reassuring before tagging.

## Issues closed

This PR brings the codebase from the last released tag (`v1.6608.0`) up to **v1.7196.0** end-to-end. The intermediate `v1.6608.1` and `v1.6608.2` work was already merged upstream (commits `ad79faa` and `0e85ec2`); merging this PR makes the version-detection issues for both of them obsolete as well.

- Closes #85 (v1.6608.1 detected) - already covered by upstream commit `ad79faa`, no longer actionable once master ships v1.7196.0.
- Closes #86 (v1.6608.2 detected) - already covered by upstream commit `0e85ec2`, no longer actionable once master ships v1.7196.0.
- Closes #88 (v1.7196.0 detected) - this PR is exactly the work that issue tracked.
- Closes #90 (Three patches break against v1.7196.0) - the companion bug report I filed alongside this PR with the full failure analysis.
