### PR TITLE
Fix: make systemd user scope optional in launcher (#89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ The `Created profile` output tells you which path was taken. Sibling files in th
 | `CLAUDE_DEV_TOOLS` | `detach` | Open Chromium DevTools on launch |
 | `CLAUDE_ELECTRON` | path | Override Electron binary path |
 | `CLAUDE_APP_ASAR` | path | Override app.asar path |
+| `CLAUDE_DISABLE_SYSTEMD_SCOPE` | `1` | Skip the `systemd-run --user --scope` wrapper. Use in sandboxes (bwrap, distrobox, ...) where the systemd private socket is unreachable. Equivalent to the `--no-systemd-scope` CLI flag. See [#89](https://github.com/patrickjaja/claude-desktop-bin/issues/89) |
 | `ELECTRON_ENABLE_LOGGING` | `1` | Log Electron main process to stderr |
 
 Set permanently in `~/.bashrc` or `~/.zshrc`, or pass per-launch: `CLAUDE_DISABLE_GPU=1 claude-desktop`
@@ -771,6 +772,7 @@ attach to the same id and survive across sessions.
 - **Custom X11 WM rules**: `WM_CLASS` / Wayland `app_id` is `claude`. Users who previously matched on `Claude` or `com.anthropic.claude-desktop` need to update their i3 / xmonad / awesome / bspwm / KWin rules. Named profiles (see [Multiple Profiles](#multiple-profiles)) get a `-<profile>` suffix on this class so each profile shows up as a separate app - write WM rules accordingly.
 - **GNOME shell extension blacklist (Rounded Window Corners Reborn, Unite, Blur My Shell, ...)**: if you added `com.anthropic.claude-quick-entry` to your extension's exclude list to hide the opaque shadow rectangle behind Quick Entry, update that entry to `claude-quick-entry`.
 - **NixOS**: the Nix package materialises a renamed Electron binary (`claude`) for correct Wayland `app_id`, but does not use `systemd-run --scope`. Portal identity may not resolve on GNOME Wayland - use `--install-gnome-hotkey` instead. Other sessions (KDE, Hyprland, Sway, X11) are unaffected.
+- **Sandboxes / containers without a reachable user-systemd** (bwrap, distrobox, restricted Flatpaks): the launcher auto-detects when `$XDG_RUNTIME_DIR/systemd/private` is missing and skips the scope wrap. Portal identity may not resolve in these environments; the app still starts. If the socket exists but is still unreachable (SELinux, bind-mount filters), force the bypass with `--no-systemd-scope` or `CLAUDE_DISABLE_SYSTEMD_SCOPE=1`. See [#89](https://github.com/patrickjaja/claude-desktop-bin/issues/89).
 
 ## Tips
 - Press **Alt** to toggle the app menu bar (Electron default)

--- a/scripts/claude-desktop-launcher.sh
+++ b/scripts/claude-desktop-launcher.sh
@@ -12,6 +12,10 @@
 #   CLAUDE_DISABLE_GPU=full  - Disable GPU entirely (more aggressive fallback)
 #   CLAUDE_ELECTRON          - Override path to Electron binary
 #   CLAUDE_APP_ASAR          - Override path to app.asar
+#   CLAUDE_DISABLE_SYSTEMD_SCOPE=1
+#                            - Skip the systemd --user --scope wrapper (for
+#                              sandboxes without access to the systemd private
+#                              socket; portal app identity may not resolve)
 
 set -euo pipefail
 
@@ -44,8 +48,10 @@ if [[ -z "${CLAUDE_PROFILE:-}" && "$_invocation_basename" =~ ^claude-desktop-([a
     CLAUDE_PROFILE="${BASH_REMATCH[1]}"
 fi
 
-# Strip --profile=<name> / --profile <name> from argv before subcommand
-# dispatch and Electron pass-through.
+# Strip launcher-only flags from argv before subcommand dispatch and Electron
+# pass-through:
+#   --profile=NAME / --profile NAME: sets CLAUDE_PROFILE
+#   --no-systemd-scope:              sets CLAUDE_DISABLE_SYSTEMD_SCOPE=1
 _filtered_args=()
 while (( $# > 0 )); do
     case "$1" in
@@ -60,6 +66,10 @@ while (( $# > 0 )); do
                 exit 2
             fi
             CLAUDE_PROFILE="$1"
+            shift
+            ;;
+        --no-systemd-scope)
+            CLAUDE_DISABLE_SYSTEMD_SCOPE=1
             shift
             ;;
         *)
@@ -657,6 +667,11 @@ _diagnose() {
         fi
     fi
     echo "systemd-run = $(command -v systemd-run || echo '(missing)')"
+    if [[ -n "${XDG_RUNTIME_DIR:-}" && -S "${XDG_RUNTIME_DIR}/systemd/private" ]]; then
+        echo "systemd user socket = ${XDG_RUNTIME_DIR}/systemd/private (present)"
+    else
+        echo "systemd user socket = (missing or unreachable; scope wrap will be skipped)"
+    fi
     echo "gsettings = $(command -v gsettings || echo '(missing)')"
     echo "gdbus = $(command -v gdbus || echo '(missing)')"
     echo
@@ -777,6 +792,10 @@ Options:
   --delete-profile=NAME     Remove the entry points for profile NAME. User data
                             (~/.config/Claude-NAME, ~/.claude-NAME) is preserved.
   --list-profiles           List installed profiles.
+  --no-systemd-scope        Skip the systemd --user --scope wrapper for this
+                            launch. Use in sandboxes (bwrap, distrobox, ...)
+                            where the systemd private socket is unreachable.
+                            Same as setting CLAUDE_DISABLE_SYSTEMD_SCOPE=1.
   --help, -h                Show this help message.
 
 Environment variables:
@@ -789,6 +808,10 @@ Environment variables:
   CLAUDE_DISABLE_GPU=full   Disable GPU entirely (more aggressive fallback).
   CLAUDE_ELECTRON=PATH      Override path to Electron binary.
   CLAUDE_APP_ASAR=PATH      Override path to app.asar.
+  CLAUDE_DISABLE_SYSTEMD_SCOPE=1
+                            Skip the systemd --user --scope wrapper (for
+                            sandboxes without access to the systemd private
+                            socket; portal app identity may not resolve).
 
 All other arguments are passed through to Electron.
 HELP
@@ -1076,11 +1099,19 @@ log "Launching: $ELECTRON_BIN $APP_ASAR ${ELECTRON_ARGS[*]} $*"
 # xdg-desktop-portal a second identity signal alongside the Wayland app_id /
 # X11 WM_CLASS, which come from the binary basename. Both must match APP_ID.
 # Fall back to direct exec in environments without user systemd (rare).
-if command -v systemd-run &>/dev/null && [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+# Three gates: explicit opt-out, binary present, runtime dir set, and the
+# user-systemd private socket actually reachable. The last check matters in
+# sandboxes (bwrap, distrobox, some container setups) where `systemd-run`
+# exists but the socket is filtered: without the probe we would `exec` into
+# systemd-run and die there, with no fallback. See issue #89.
+if [[ "${CLAUDE_DISABLE_SYSTEMD_SCOPE:-}" != '1' ]] \
+    && command -v systemd-run &>/dev/null \
+    && [[ -n "${XDG_RUNTIME_DIR:-}" ]] \
+    && [[ -S "${XDG_RUNTIME_DIR}/systemd/private" ]]; then
     exec systemd-run --user --scope --quiet \
         --unit="app-${APP_ID}${profile_suffix}-$$.scope" \
         --description='Claude Desktop' \
         -- "$ELECTRON_BIN" "$APP_ASAR" "${ELECTRON_ARGS[@]}" "$@"
 fi
-log 'systemd-run unavailable — launching without scope; xdg-desktop-portal may fail to identify the app'
+log 'systemd user scope unavailable (binary missing, socket unreachable, or CLAUDE_DISABLE_SYSTEMD_SCOPE=1): launching without scope; xdg-desktop-portal may fail to identify the app'
 exec "$ELECTRON_BIN" "$APP_ASAR" "${ELECTRON_ARGS[@]}" "$@"


### PR DESCRIPTION
## Summary

Closes #89.

The launcher in `scripts/claude-desktop-launcher.sh` previously gated `systemd-run --user --scope` only on the binary's existence and `XDG_RUNTIME_DIR`. In sandboxes (bwrap, distrobox, container setups) where the binary is present but the systemd private socket (`$XDG_RUNTIME_DIR/systemd/private`) is filtered, `exec systemd-run` replaces the launcher process and then fails when connecting to the socket. Because the call is `exec`, there is no fallback path: Claude Desktop never starts.

The fallback branch at the end of that block (`exec "$ELECTRON_BIN" ...`) is correct, just unreachable in this scenario because the gate condition is too permissive.

## Changes

- **Socket probe in the gate**: `[[ -S "${XDG_RUNTIME_DIR}/systemd/private" ]]` is now checked before `exec systemd-run`. The sandbox case (binary present, socket missing) now falls through to the existing direct-`exec` fallback automatically, no configuration needed.
- **`--no-systemd-scope` CLI flag**: parsed in the existing `--profile` argv filter and stripped before Electron pass-through. Sets `CLAUDE_DISABLE_SYSTEMD_SCOPE=1` internally.
- **`CLAUDE_DISABLE_SYSTEMD_SCOPE=1` env var**: equivalent to the flag, for the residual case where the socket exists but is unreachable (SELinux policy, MAC bind-mount filters). Naming symmetric to existing `CLAUDE_DISABLE_GPU`.
- **`--diagnose` output**: shows `systemd user socket = ... (present|missing)` alongside the existing `systemd-run = ...` line, so future bug reports on this path are self-explanatory.

The fallback log line was updated to spell out all three reasons the scope wrap can be skipped, instead of saying "systemd-run unavailable" when the binary is in fact available.

## Default behaviour unchanged

On a regular desktop with a running user systemd:
- `CLAUDE_DISABLE_SYSTEMD_SCOPE` unset → opt-out check passes
- `systemd-run` binary present → passes
- `XDG_RUNTIME_DIR` non-empty → passes
- `$XDG_RUNTIME_DIR/systemd/private` is a socket → passes

All four conditions true, `exec systemd-run` runs exactly as before. Portal identity, KDE global shortcuts, persistent xdg-desktop-portal authorizations: all unaffected.

## Test plan

- [x] `bash -n scripts/claude-desktop-launcher.sh` clean
- [x] `shellcheck -S error scripts/claude-desktop-launcher.sh` clean (run via `koalaman/shellcheck:stable` Docker image to match the CI level in `scripts/build-patched-tarball.sh:351`)
- [x] Gate-logic unit test, 4 scenarios:
  1. Normal desktop (all conditions true) → uses systemd-run
  2. `CLAUDE_DISABLE_SYSTEMD_SCOPE=1` → fallback
  3. Fake `XDG_RUNTIME_DIR` pointing at a nonexistent path (sandbox case) → fallback
  4. Empty `XDG_RUNTIME_DIR` → fallback (no crash, short-circuit on the `-n` check)
- [x] Argv-parser unit test, 5 scenarios: no flags, just `--no-systemd-scope`, flag in middle of argv, combined with `--profile=NAME`, flag does not swallow a trailing arg.
- [ ] End-to-end sandbox repro: would need a bwrap setup without `/run/user/$UID/systemd`; not run by me. The user who filed #89 is in a position to verify.

## Scope: launcher only

No changes to Nim patches, `app.asar`, Electron binary, or any of the JS injection. The diff is confined to `scripts/claude-desktop-launcher.sh` (parser, gate, header comment, help text, diagnose block) and a `CHANGELOG.md` entry.