### PR TITLE
Linux: integrated titlebar by default with `--native-titlebar` opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to claude-desktop-bin AUR package will be documented in this file.
 
+## Unreleased - Integrated titlebar on Linux by default
+
+- **Linux now uses the Windows-style integrated titlebar** (`frame:false` + `titleBarOverlay` themed via Anthropic's own background helper, theme-aware) instead of the native GTK frame. Opt out with `CLAUDE_NATIVE_TITLEBAR=1` or the launcher flag `--native-titlebar`. Quick Entry is unaffected.
+- New patches: `fix_native_frame.nim` (main process, conditional window options + theme-update gate + opaque overlay color in integrated mode) and `fix_native_frame_renderer.nim` (collapses the upstream `nc-drag` div in `MainWindowPage-*.js` so it no longer absorbs pointer events over the UI buttons).
+
 ## 2026-05-19 - Enhanced version-check issue template with Linux compatibility checklist
 
 - **Version-check workflow** now creates comprehensive issues with:

--- a/README.md
+++ b/README.md
@@ -489,7 +489,8 @@ The package applies several patches to make Claude Desktop work on Linux. Each p
 | ~~`fix_ion_dist_linux.nim`~~ | **Removed** - Anthropic upstreamed Linux support in ion-dist SPA (v1.8089.0) | N/A |
 | `fix_locale_paths.nim` | Redirects locale file paths to Linux install location (also handles `index.pre.js` if present) | Global string replace on `process.resourcesPath` |
 | `fix_marketplace_linux.nim` | Forces host-local mode for plugin operations (no VM); promotes `$HOME`-scoped CLI plugins to user scope so they appear under "Personal Plugins" | `rg -o 'function \w+\(\w+\)\{return\(\w+==null.*mode.*ccd' index.js` |
-| `fix_native_frame.nim` | Native window frames on Linux, preserves Quick Entry transparency | `rg -o 'titleBarStyle.{0,30}' index.js` |
+| `fix_native_frame.nim` | Default: Windows-style integrated titlebar on Linux. Opt-out via `CLAUDE_NATIVE_TITLEBAR=1` or `--native-titlebar` to restore the native GTK frame. Preserves Quick Entry. | `rg -o 'titleBarStyle:process\.platform.{0,80}' index.js` |
+| `fix_native_frame_renderer.nim` | Renderer companion: collapses upstream's main-window `nc-drag` div so it no longer absorbs pointer events over the Anthropic UI buttons. | `rg -o 'className:"nc-drag"' MainWindowPage-*.js` |
 | `fix_office_addin_linux.nim` | Extends Office Addin connected file detection to include Linux (MCP server platform gate removed upstream in v1.8089.0) | `rg -o '.{0,30}louderPenguinEnabled.{0,30}' index.js` |
 | `fix_process_argv_renderer.nim` | Injects `process.argv=[]` in renderer preload to prevent TypeError | `rg -o '.{0,30}\.argv.{0,30}' mainView.js` |
 | `fix_profile_url_routing.nim` | Hooks `shell.openExternal` to write a per-profile auth-marker file before opening SSO URLs, so the system `claude://` handler can route callbacks to the right profile | `rg -o 'shell\.openExternal' index.js` |

--- a/patches/fix_native_frame.nim
+++ b/patches/fix_native_frame.nim
@@ -1,110 +1,125 @@
 # @patch-target: app.asar.contents/.vite/build/index.js
 # @patch-type: nim
-# Patch Claude Desktop to use native window frames on Linux.
-# Steps: preserve Quick Entry frame, replace frame:!1, titleBarStyle, autoHideMenuBar, icon.
+#
+# Make Claude Desktop use the integrated (Windows-style) titlebar on Linux
+# by default: min/max/close are drawn as an overlay inside the web content
+# and the tab strip / menu / nav buttons share that bar. Upstream's Linux
+# build instead opens a native GTK window because `titleBarOverlay:Io` is
+# gated on `Io = process.platform === "win32"`, and the helper that pushes
+# theme updates is gated the same way.
+#
+# Three patches together do the job:
+#   1. Open the main BrowserWindow with frame:false + a real titleBarOverlay
+#      style object on Linux (plus autoHideMenuBar + icon).
+#   2. Open the setTitleBarOverlay theme-update gate for Linux so the
+#      overlay colors follow Anthropic's `Hb` flag and the OS theme.
+#   3. Replace one transparent placeholder (`cve = "#00000000"`) with
+#      Anthropic's opaque window background in Linux integrated mode.
+#      Electron on Wayland silently substitutes a grey strip for that
+#      transparent value, so without this swap the overlay always looks
+#      like a hard-coded grey block.
+#
+# All three behaviors gate on CLAUDE_NATIVE_TITLEBAR: unset (or anything
+# other than "1") = integrated mode; "1" = restore the GTK frame. The
+# launcher's `--native-titlebar` flag sets the env var.
+#
+# Anthropic's bundle is minified and renames identifiers between releases.
+# We capture two of them (the background helper and the Electron module
+# alias) at patch time so the generated code references the current names
+# and we fail loudly if either disappears.
+#
+# Quick Entry's BrowserWindow is matched by `transparent:!0,frame:!1` and
+# has no titleBarOverlay -- none of the patterns below touch it.
 
 import std/[os, strformat, strutils]
 import regex
 
+const ICON = "/usr/share/icons/hicolor/256x256/apps/claude-desktop.png"
+const LINUX_NATIVE =
+  "process.platform===\"linux\"&&process.env.CLAUDE_NATIVE_TITLEBAR===\"1\""
+const LINUX_INTEGRATED =
+  "process.platform===\"linux\"&&process.env.CLAUDE_NATIVE_TITLEBAR!==\"1\""
+
+proc capture(s: string, pat: Regex2, name: string): string =
+  ## Capture group 1 of `pat` from `s`, or raise with `name` in the message.
+  var m: RegexMatch2
+  if not s.find(pat, m):
+    raise newException(ValueError, "fix_native_frame: " & name & " not found")
+  s[m.group(0)]
+
 proc apply*(input: string): string =
+  if "CLAUDE_NATIVE_TITLEBAR" in input:
+    echo "  [INFO] already patched"
+    return input
   result = input
 
-  # Step 1: Check if transparent window pattern exists (Quick Entry)
-  let quickEntryPattern = "transparent:!0,frame:!1"
-  let hasQuickEntry = quickEntryPattern in result
-  if hasQuickEntry:
-    echo "  [OK] Quick Entry pattern found (will preserve)"
-  else:
-    echo "  [INFO] Quick Entry pattern not found (may be already patched)"
-
-  # Step 2: Temporarily mark the Quick Entry pattern
-  let marker = "__QUICK_ENTRY_FRAME_PRESERVE__"
-  if hasQuickEntry:
-    result = result.replace(quickEntryPattern, "transparent:!0," & marker)
-
-  # Step 3: Replace frame:!1 (false) with frame:true for main window
-  let framePat = re2"frame\s*:\s*!1"
-  var countFrame = 0
-  result = result.replace(
-    framePat,
-    proc(m: RegexMatch2, s: string): string =
-      inc countFrame
-      "frame:true",
+  # Anthropic identifiers (minified, renamed between releases):
+  #   bgFn      e.g. "G$" -- window background color, called as G$().
+  #   electron  e.g. "cA" -- alias for require("electron"), used for
+  #                          nativeTheme.shouldUseDarkColors.
+  let bgFn = result.capture(
+    re2"""backgroundColor:([\w$]+)\(\),opacity:""", "backgroundColor function"
   )
-  if countFrame > 0:
-    echo &"  [OK] frame:!1 -> frame:true: {countFrame} match(es)"
-  else:
-    echo "  [INFO] No frame:!1 found outside Quick Entry (main window uses native frames by default)"
-
-  # Step 4: Restore Quick Entry frame setting
-  if hasQuickEntry:
-    result = result.replace("transparent:!0," & marker, quickEntryPattern)
-    echo "  [OK] Restored Quick Entry frame:!1 (transparent)"
-
-  # Step 5: Replace titleBarStyle:"hidden" with platform-conditional for main window
-  let mainTitlebarPat = re2"titleBarStyle:""hidden"",(titleBarOverlay:\w+)"
-  var countTitlebar = 0
-  result = result.replace(
-    mainTitlebarPat,
-    proc(m: RegexMatch2, s: string): string =
-      inc countTitlebar
-      let overlay = s[m.group(0)]
-      "titleBarStyle:process.platform===\"linux\"?\"default\":\"hidden\"," & overlay,
+  let electron = result.capture(
+    re2"""([\w$]+)\.nativeTheme\.shouldUseDarkColors""", "electron alias"
   )
-  if countTitlebar > 0:
-    echo &"  [OK] titleBarStyle:\"hidden\" -> platform-conditional: {countTitlebar} match(es)"
-  else:
-    if "titleBarStyle:process.platform===\"linux\"?\"default\":\"hidden\"" in result:
-      echo "  [INFO] titleBarStyle already patched"
-    else:
-      echo "  [FAIL] titleBarStyle:\"hidden\" pattern not found near titleBarOverlay"
-      raise
-        newException(ValueError, "fix_native_frame: titleBarStyle pattern not found")
 
-  # Step 6: Add autoHideMenuBar:true for Linux
-  let autohidePat =
-    re2"(titleBarStyle:process\.platform===""linux""\?""default"":""hidden""),(titleBarOverlay:\w+)"
-  var countAutohide = 0
+  # Patch 1: main BrowserWindow options. We splice five runtime-conditional
+  # options into the existing comma-list right after titleBarOverlay:
+  #   titleBarStyle:    "default" on Linux opt-out, "hidden" otherwise.
+  #   titleBarOverlay:  Anthropic-themed style object on Linux integrated,
+  #                     upstream var (true on win32, false elsewhere) otherwise.
+  #   frame:            false on Linux integrated, true otherwise.
+  #   autoHideMenuBar:  true on Linux (Alt brings the GTK menu bar back).
+  #   icon:             Linux PNG path on Linux, undefined elsewhere.
+  let overlayStyle = "{color:" & bgFn & "(),symbolColor:" & electron &
+    ".nativeTheme.shouldUseDarkColors?\"#fff\":\"#000\",height:36}"
+  var n = 0
   result = result.replace(
-    autohidePat,
+    re2"""titleBarStyle:"hidden",titleBarOverlay:([\w$]+)""",
     proc(m: RegexMatch2, s: string): string =
-      inc countAutohide
-      let titlebar = s[m.group(0)]
-      let overlay = s[m.group(1)]
-      titlebar & ",autoHideMenuBar:process.platform===\"linux\"," & overlay,
+      inc n
+      "titleBarStyle:" & LINUX_NATIVE & "?\"default\":\"hidden\"," &
+        "titleBarOverlay:(" & LINUX_INTEGRATED & ")?" & overlayStyle & ":" &
+        s[m.group(0)] & ",frame:!(" & LINUX_INTEGRATED & ")," &
+        "autoHideMenuBar:process.platform===\"linux\"," &
+        "icon:process.platform===\"linux\"?\"" & ICON & "\":void 0",
   )
-  if countAutohide > 0:
-    echo &"  [OK] autoHideMenuBar added: {countAutohide} match(es)"
-  else:
-    if "autoHideMenuBar:process.platform===\"linux\"" in result:
-      echo "  [INFO] autoHideMenuBar already patched"
-    else:
-      echo "  [FAIL] autoHideMenuBar pattern not found"
-      raise
-        newException(ValueError, "fix_native_frame: autoHideMenuBar pattern not found")
+  if n != 1:
+    raise newException(ValueError, &"main window pattern: {n}/1")
+  echo &"  [OK] main window options: {n}"
 
-  # Step 7: Add window icon for Linux
-  let iconPat =
-    re2"(autoHideMenuBar:process\.platform===""linux""),(titleBarOverlay:\w+)"
-  var countIcon = 0
+  # Patch 2: setTitleBarOverlay theme-update gate. Upstream guards the
+  # forEach-all-windows call with `Io&&` (win32 only). We OR in Linux
+  # integrated mode so the overlay receives theme updates there too.
+  n = 0
   result = result.replace(
-    iconPat,
+    re2"""\bIo&&([\w$]+)\.BrowserWindow\.getAllWindows\(\)\.forEach""",
     proc(m: RegexMatch2, s: string): string =
-      inc countIcon
-      let autohide = s[m.group(0)]
-      let overlay = s[m.group(1)]
-      autohide &
-        ",icon:process.platform===\"linux\"?\"/usr/share/icons/hicolor/256x256/apps/claude-desktop.png\":void 0," &
-        overlay,
+      inc n
+      "(Io||(" & LINUX_INTEGRATED & "))&&" & s[m.group(0)] &
+        ".BrowserWindow.getAllWindows().forEach",
   )
-  if countIcon > 0:
-    echo &"  [OK] window icon added: {countIcon} match(es)"
-  else:
-    if "icon:process.platform===\"linux\"" in result:
-      echo "  [INFO] window icon already patched"
-    else:
-      echo "  [FAIL] window icon pattern not found"
-      raise newException(ValueError, "fix_native_frame: window icon pattern not found")
+  if n != 1:
+    raise newException(ValueError, &"setTitleBarOverlay gate: {n}/1")
+  echo &"  [OK] setTitleBarOverlay gate: {n}"
+
+  # Patch 3: opaque-color swap inside the helper that builds the overlay
+  # style. The non-Hb branch uses `cve = "#00000000"`, which Electron on
+  # Linux Wayland treats as "use default" and paints as a grey strip.
+  # Swap it for `bgFn()` in Linux integrated mode so the overlay actually
+  # matches the window background. Two occurrences: one per theme.
+  let linuxBg = "(" & LINUX_INTEGRATED & ")?" & bgFn & "():cve"
+  n = 0
+  result = result.replace(
+    re2"""(\{color:[\w$]+\?"#[0-9a-fA-F]+":)cve(,symbolColor:)""",
+    proc(m: RegexMatch2, s: string): string =
+      inc n
+      s[m.group(0)] & linuxBg & s[m.group(1)],
+  )
+  if n != 2:
+    raise newException(ValueError, &"T8 cve references: {n}/2")
+  echo &"  [OK] T8 cve -> bgFn() in Linux integrated mode: {n}"
 
 when isMainModule:
   if paramCount() != 1:
@@ -112,14 +127,11 @@ when isMainModule:
     quit(1)
   let file = paramStr(1)
   echo "=== Patch: fix_native_frame ==="
-  echo &"  Target: {file}"
-  if not fileExists(file):
-    echo &"  [FAIL] File not found: {file}"
-    quit(1)
-  let input = readFile(file)
-  let output = apply(input)
-  if output != input:
-    writeFile(file, output)
-    echo "  [PASS] Native frame patched successfully"
+  echo "  Target: " & file
+  let orig = readFile(file)
+  let patched = apply(orig)
+  if patched != orig:
+    writeFile(file, patched)
+    echo "  [PASS] native frame patched"
   else:
-    echo "  [PASS] No changes needed (main window already uses native frames)"
+    echo "  [PASS] no changes needed"

--- a/patches/fix_native_frame_renderer.nim
+++ b/patches/fix_native_frame_renderer.nim
@@ -1,0 +1,66 @@
+# @patch-target: app.asar.contents/.vite/renderer/main_window/assets/MainWindowPage-*.js
+# @patch-type: nim
+#
+# Renderer-side companion to fix_native_frame.nim.
+#
+# Problem: with the integrated titlebar on Linux, the UI buttons (menu /
+# sidebar toggle / search / back / forward) don't respond to hover or
+# clicks. Cause: the React title-bar component renders a 36px-tall div
+# with `-webkit-app-region: drag` (CSS class `nc-drag`) on macOS and Linux
+# but `null` on Windows. On Linux integrated mode that drag region sits
+# above the UI buttons and absorbs every pointer event before they get it.
+# On macOS it's harmless because the height resolves to 0.
+#
+# Fix: make the main window branch return null on all platforms, matching
+# upstream's Windows behavior. Effects:
+#   * Windows:           unchanged (already returned null).
+#   * macOS:             unchanged (was a 0px div, paints nothing either way).
+#   * Linux integrated:  pointer events reach the UI buttons; Electron's
+#                        titleBarOverlay still provides a draggable area.
+#   * Linux GTK opt-out: also a no-op visually -- the GTK frame covered
+#                        the div anyway, and the div was never interactive.
+#
+# Unconditional rather than gated on CLAUDE_NATIVE_TITLEBAR because the
+# renderer can't read process.env: the preload (mainView.js) exposes a
+# filtered process object with arch / platform / type / versions / argv
+# only, no env. Since the change is a no-op everywhere else, gating is
+# unnecessary.
+
+import std/[os, strformat, strutils]
+import regex
+
+proc apply*(input: string): string =
+  result = input
+  if not result.contains("className:\"nc-drag\"") and result.contains("isMainWindow"):
+    echo "  [INFO] already patched"
+    return
+
+  # Match the exact Pe() drag-region statement. Minified names (`z`, `e`,
+  # `r`, `l`, the inner height var) are placeholders; we capture only the
+  # isMainWindow argument so the rewritten `if(e)return null;` references
+  # the same value.
+  var n = 0
+  result = result.replace(
+    re2 r"""if\(!([\w$]+)&&([\w$]+)\)return [\w$]+===0\?null:[\w$]+\.jsx\("div",\{className:"nc-drag",style:\{height:`\$\{[\w$]+\}px`,width:"100%"\}\}\);""",
+    proc(m: RegexMatch2, s: string): string =
+      inc n
+      "if(" & s[m.group(1)] & ")return null;",
+  )
+  if n != 1:
+    raise newException(ValueError, &"Pe nc-drag pattern: {n}/1")
+  echo &"  [OK] Pe nc-drag collapsed to if(e)return null;: {n}"
+
+when isMainModule:
+  if paramCount() != 1:
+    echo "Usage: fix_native_frame_renderer <file>"
+    quit(1)
+  let file = paramStr(1)
+  echo "=== Patch: fix_native_frame_renderer ==="
+  echo "  Target: " & file
+  let orig = readFile(file)
+  let patched = apply(orig)
+  if patched != orig:
+    writeFile(file, patched)
+    echo "  [PASS] Pe drag region patched"
+  else:
+    echo "  [PASS] no changes needed"

--- a/scripts/claude-desktop-launcher.sh
+++ b/scripts/claude-desktop-launcher.sh
@@ -16,6 +16,10 @@
 #                            - Skip the systemd --user --scope wrapper (for
 #                              sandboxes without access to the systemd private
 #                              socket; portal app identity may not resolve)
+#   CLAUDE_NATIVE_TITLEBAR=1 - Restore the native GTK titlebar on Linux
+#                              (frame:true + titleBarStyle:"default"). Default
+#                              is the integrated Windows-style titlebar. Also
+#                              via --native-titlebar.
 
 set -euo pipefail
 
@@ -52,6 +56,7 @@ fi
 # pass-through:
 #   --profile=NAME / --profile NAME: sets CLAUDE_PROFILE
 #   --no-systemd-scope:              sets CLAUDE_DISABLE_SYSTEMD_SCOPE=1
+#   --native-titlebar:               sets CLAUDE_NATIVE_TITLEBAR=1
 _filtered_args=()
 while (( $# > 0 )); do
     case "$1" in
@@ -70,6 +75,10 @@ while (( $# > 0 )); do
             ;;
         --no-systemd-scope)
             CLAUDE_DISABLE_SYSTEMD_SCOPE=1
+            shift
+            ;;
+        --native-titlebar)
+            export CLAUDE_NATIVE_TITLEBAR=1
             shift
             ;;
         *)


### PR DESCRIPTION
Closes #99.

## What this PR does

Makes the main window use the same integrated titlebar (`frame:false` + `titleBarOverlay`) on Linux that Windows and macOS already get. The tab strip / menu button / sidebar toggle / search / back-forward arrows now share one continuous bar at the top, matching the Windows look. Users who prefer the previous native GTK frame can set `CLAUDE_NATIVE_TITLEBAR=1` or pass `--native-titlebar` to the launcher.

## Visual comparison

Windows:

<img width="827" height="89" alt="Image" src="https://github.com/user-attachments/assets/4f06ffc3-3cb8-4522-94f6-6849a7f76411" />

Linux current:

<img width="916" height="109" alt="Image" src="https://github.com/user-attachments/assets/3a0e10aa-5130-48dd-9f7b-3c079ac88363" />

Linux proposed:

<img width="1001" height="71" alt="Image" src="https://github.com/user-attachments/assets/8a906256-33c7-4545-b007-b72576c0f2a6" />

## Why the upstream behavior is what it is

Anthropic's bundle constructs the main `BrowserWindow` with `titleBarStyle:"hidden"` and `titleBarOverlay:Io`, where `Io = process.platform === "win32"`. On Linux `Io` is `false`, so the overlay is never enabled, Electron falls back to a native frame, and `setTitleBarOverlay` calls in the theme-update helper are gated by the same `Io &&` short-circuit. That is consistent with Anthropic only officially supporting Windows and macOS, but it produces a visibly different layout on Linux.

## How the fix works

Four sub-patches in two files cover four distinct problems:

### `patches/fix_native_frame.nim` (against `index.js`, main process)

1. **Main `BrowserWindow` options.** Splice five runtime-conditional options into the comma-list that already contains `titleBarStyle:"hidden",titleBarOverlay:<var>`:
   * `titleBarStyle` becomes `"default"` only on Linux opt-out, `"hidden"` everywhere else.
   * `titleBarOverlay` becomes a real style object on Linux integrated, the upstream `Io` var (true on win32, false elsewhere) otherwise.
   * `frame` becomes `false` on Linux integrated, `true` everywhere else.
   * `autoHideMenuBar` is set on Linux so the GTK menu bar stays hidden but accessible via Alt.
   * `icon` points at the Linux PNG so Wayland window lists show the right icon.

2. **`setTitleBarOverlay` gate.** Replace `Io && <electron>.BrowserWindow.getAllWindows().forEach(...)` with `(Io || (linux && integrated)) && ...` so the helper runs on Linux too and updates the overlay colors whenever the OS theme or Anthropic's internal `Hb` flag (Code tab) flips.

3. **Wayland transparency workaround.** Inside Anthropic's `T8`-style helper there are two style objects of the shape `{ color: Hb?"#141412":cve, ... }` (one per theme). `cve` is `"#00000000"`. On Linux Wayland Electron silently substitutes a default grey strip for that transparent value, so even with the overlay enabled the buttons sit on a hard-coded grey block. The patch rewrites the cve reference to `(linux && integrated) ? <bgFn>() : cve` so Electron sees an opaque color in our mode and paints the strip in Anthropic's actual window background. Other platforms keep `cve`.

### `patches/fix_native_frame_renderer.nim` (against `MainWindowPage-*.js`, renderer)

4. **Pointer-event absorber.** The React title-bar component renders a 36 px `<div class="nc-drag">` for the main window on macOS and Linux, but `null` on Windows. With the integrated titlebar in place that drag region sits on top of the Anthropic UI buttons and absorbs every hover/click before they get there. The patch collapses the conditional to `if(e) return null;` on all platforms (which is what Windows already does). On macOS it was a 0 px div anyway, so the change is a no-op there; in Linux opt-out mode it was hidden under the GTK frame and not interactive anyway.

## Why this approach and not another

- **Why opt-out rather than opt-in.** The integrated look is what the app was clearly designed for (it's already what Windows and macOS get). Making it the default on Linux too aligns with that intent. The opt-out env var keeps the change risk-free for users who explicitly prefer the GTK frame.

- **Why dynamic identifier capture instead of hardcoded names.** Anthropic minifies the bundle and renames identifiers on most releases. `G$` (background helper), `cA` (`require("electron")` alias), `Io`, `cve` etc. could all change. The two we need to splice into the generated code (`bgFn` and the Electron alias) are captured by regex at patch time. The patch fails loudly with a descriptive error if capture fails, rather than silently drifting onto hard-coded values that would diverge from Anthropic's design.

- **Why opaque background instead of just leaving `cve` transparent.** This is the non-obvious one. Empirically, `setTitleBarOverlay({ color: "#00000000", ... })` on Linux Wayland (tested on GNOME Mutter and XWayland) does not produce a transparent strip; Electron treats it as "no preference" and paints its default grey. Swapping to an opaque value that matches the window background is the only way to get a strip that visually disappears.

- **Why an unconditional renderer patch.** The renderer can't read `process.env.CLAUDE_NATIVE_TITLEBAR`: the preload (`mainView.js`) exposes a filtered `process` object containing only `arch`, `platform`, `type`, `versions` and `argv`. Threading the flag through the preload would add complexity for no benefit, because removing the `nc-drag` div is a no-op everywhere except in Linux integrated mode.

- **Why Quick Entry stays untouched.** The Quick Entry window is constructed with `transparent:!0,frame:!1` and has no `titleBarOverlay`. None of the patterns in this PR match that constructor, so its transparency and frameless behavior are preserved.

## Testing

- Fedora 43, GNOME on Wayland (Mutter), Claude Desktop 1.8089.0, Electron 42.
- Default (`claude-desktop`): integrated titlebar matches Windows look. Theme switch in GNOME light/dark updates the strip color via the unblocked `setTitleBarOverlay` gate. Hover/click work on menu, sidebar toggle, search and nav arrows. Window dragging works via the overlay's own drag area.
- Opt-out (`claude-desktop --native-titlebar` or `CLAUDE_NATIVE_TITLEBAR=1 claude-desktop`): GTK frame is back, Anthropic top bar below it, behavior identical to the previous release.
- Quick Entry: unchanged (transparent, frameless).
- Patch idempotency: applying the patches twice on the same file is a no-op.
- Each sub-patch fails the build with a descriptive error if its regex does not match, so an Anthropic bundle change won't ship as a silently-broken release.