### PR TITLE
Add launcher.log rotation to bound unbounded growth (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to claude-desktop-bin AUR package will be documented in this file.
 
+## 2026-06-10 - Launcher log rotation (#132)
+
+### Issue
+
+- [#132](https://github.com/patrickjaja/claude-desktop-bin/issues/132): Reported that `_previous_launch_hit_gpu_fatal` hangs the launcher on large log files via an O(n^2) awk scan of the whole `launcher.log` on every startup. **Investigation result:** that function, `setup_logging`, `build_electron_args` and the `~/.cache/claude-desktop-debian/` cache path do not exist anywhere in this repo - they belong to the separate `aaddrick/claude-desktop-debian` project. This launcher writes to `~/.cache/claude-desktop/launcher.log` and only ever reads it via `tail -10` for `--diagnostics`, so the reported O(n^2) hang cannot occur here. The one applicable half of the report - unbounded log growth - did apply: `log()` appended without any size cap.
+
+### Fix
+
+- **`scripts/claude-desktop-launcher.sh`** - rotate `launcher.log` to `launcher.log.old` once it exceeds 2 MiB, checked once per startup before `log()` is defined. Every step is guarded (`stat` failure -> `0`, numeric regex guard, `mv` failure ignored) so the rotation can never itself prevent Claude from launching.
+
 ## 2026-06-10 (v1.11847.5-2) - 2 new patches: Linux memory-pressure metric + suppressed renderer-death logging (#128)
 
 ### Issue

--- a/scripts/claude-desktop-launcher.sh
+++ b/scripts/claude-desktop-launcher.sh
@@ -1109,6 +1109,21 @@ LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-desktop"
 mkdir -p "$LOG_DIR"
 LOG_FILE="$LOG_DIR/launcher.log"
 
+# Rotate launcher.log if it grows too large. log() only ever appends (one or
+# more lines per launch), so without a cap the file grows unboundedly over
+# weeks of use. We keep a single rotated backup (launcher.log.old). This block
+# runs on every startup and must never abort the launcher itself, so every
+# step is guarded: a missing file or an odd stat must not stop Claude from
+# opening. See issue #132 (the unbounded-growth half; the O(n^2) awk hang it
+# also describes belongs to a different project and does not exist here).
+_LOG_MAX_BYTES=$((2 * 1024 * 1024))  # 2 MiB
+if [[ -f $LOG_FILE ]]; then
+    _log_size=$(stat -c %s "$LOG_FILE" 2>/dev/null || echo 0)
+    if [[ $_log_size =~ ^[0-9]+$ ]] && (( _log_size > _LOG_MAX_BYTES )); then
+        mv -f "$LOG_FILE" "$LOG_FILE.old" 2>/dev/null || true
+    fi
+fi
+
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $1" >> "$LOG_FILE"; }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds size-based rotation for `launcher.log` in `scripts/claude-desktop-launcher.sh`. The launcher's `log()` only ever appends, with no cap, so the file grows unboundedly over weeks of use. It is now rotated to `launcher.log.old` once it exceeds 2 MiB, checked once per startup before `log()` is defined.

The rotation runs on every launch, so it is fully guarded and can never itself prevent Claude from starting:
- `stat` failure falls back to `0`
- a numeric regex guards the comparison
- an `mv` failure is ignored

## Context: issue #132

[#132](https://github.com/patrickjaja/claude-desktop-bin/issues/132) reports an O(n²) awk-over-whole-log hang in a function `_previous_launch_hit_gpu_fatal`. That function, `setup_logging`, `build_electron_args`, and the `~/.cache/claude-desktop-debian/` cache path **do not exist in this repo** — a `git grep` over `HEAD` finds none of them, and a GitHub code search locates `_previous_launch_hit_gpu_fatal` only in [`aaddrick/claude-desktop-debian` → `scripts/launcher-common.sh`](https://github.com/aaddrick/claude-desktop-debian/blob/main/scripts/launcher-common.sh). The reporter's own workaround (`truncate ~/.cache/claude-desktop-debian/launcher.log`) confirms they're running that other build.

This launcher reads `launcher.log` only via `tail -10` for `--diagnostics`, so the reported hang structurally cannot occur here. This PR therefore addresses **only** the one applicable half of the report — unbounded log growth — as defensive hardening.

## Testing

- `bash -n scripts/claude-desktop-launcher.sh` passes
- Rotation logic tested in isolation: a 3 MiB log rotates to `.old`; a small log is left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)