### PR TITLE
fix_terminal_shell_linux: spawn Linux shell instead of PowerShell (#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to claude-desktop-bin AUR package will be documented in this file.
 
+## 2026-06-18 - New patch: built-in terminal spawns a Linux shell instead of PowerShell (#143)
+
+### Built-in terminal fixed (re: #143)
+
+- **New `fix_terminal_shell_linux.nim` (51 patches total): the built-in agent/Cowork terminal now spawns the user's Linux shell instead of PowerShell.** The upstream shell-selection helper is hardcoded to PowerShell on every platform - `function <minified>(){return{shell:"powershell.exe",args:[]}}` - and its result is passed straight into node-pty's `pty.spawn(shell, args, …)` in `LocalSessions.startShellPty` (and the bash-PTY path). On Linux `powershell.exe` is not on `PATH`, so `spawn-helper`'s `execvp(3)` fails and the PTY dies immediately: the renderer shows **"Shell exited."** / "Restart shell" and `main.log` records `Shell PTY for session local_… exited with code 1`. Confirmed by forking `powershell.exe` through the bundled `pty.node`/`spawn-helper` (yields exactly `execvp(3) failed.: No such file or directory` + exit code 1), while `/bin/bash` spawns cleanly.
+- **The patch rewrites only the shell string value into a platform-aware ternary:** `shell:process.platform==="win32"?"powershell.exe":process.env.SHELL||"/bin/bash"`, leaving the (minified) function name and the `args` value untouched. Anchored on `(shell\s*:\s*)["']powershell\.exe["']`, which occurs exactly once in the bundle (the bare string `powershell.exe` appears 8x elsewhere - Windows-path detection, executable allow-sets - but only here behind a `shell:` key). The pattern is intentionally minimal so it survives re-minification: it does not depend on the per-release function name, the `args` value, whitespace, or quote style, and the replacement is Windows-semantics-preserving (on win32 it still evaluates to `"powershell.exe"`, so even an accidental second match stays correct). Idempotent via the unique `process.env.SHELL||"/bin/bash"` marker; `EXPECTED_PATCHES` = 1 with `quit(1)` on miss. Verified against the v1.13576.4 bundle: 1 match, `node --check` passes, and the rewritten shell spawns a working PTY.
+
 ## 2026-06-17 (v1.13576.0 / v1.13576.1) - Major version bump: 7 patches fixed, 1 removed, 1 added (50 total), all apply
 
 ### Cowork startup-error visibility (re: #142)

--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ The package applies several patches to make Claude Desktop work on Linux. Each p
 | `fix_renderer_gone_suppressed_log.nim` | Logs main-webview renderer deaths that upstream silently swallows (expected kills, `killed`/`clean-exit` reasons - a kernel OOM SIGKILL maps to `killed`, so OOM-killed renderers left no trace in main.log) ([#128](https://github.com/patrickjaja/claude-desktop-bin/issues/128)) | `rg -o 'render process gone \(suppressed\).{0,60}' index.js` |
 | `fix_sensitive_dirs_linux.nim` | Adds Linux entries (`.local/share/keyrings`, `.pki`, `.config/autostart`) to the sandbox sensitive-directories block list | `rg -o '\.gnupg.{0,80}' index.js` |
 | `fix_startup_settings.nim` | XDG autostart management for "Start at login" toggle; per-profile autostart files for named profiles | `rg -o 'isStartupOnLoginEnabled.{0,50}' index.js` |
+| `fix_terminal_shell_linux.nim` | Rewrites the hardcoded `powershell.exe` shell of the built-in agent/Cowork terminal to a platform-aware ternary (`$SHELL` / `/bin/bash` off-Windows), so the PTY no longer dies with exit code 1 ([#143](https://github.com/patrickjaja/claude-desktop-bin/issues/143)) | `rg -o '\{shell:"powershell\.exe".{0,20}' index.js` |
 | `fix_tray_dbus.nim` | Prevents DBus race conditions with mutex and cleanup delay | `rg -o 'menuBarEnabled.*function' index.js` |
 | `fix_tray_icon_theme.nim` | Theme-aware tray icon (light/dark) | `rg -o 'nativeTheme.{0,50}tray' index.js` |
 | ~~`fix_tray_path.py`~~ | **Removed** - tray icon paths handled by `fix_locale_paths.nim` | N/A |

--- a/patches/fix_terminal_shell_linux.nim
+++ b/patches/fix_terminal_shell_linux.nim
@@ -1,0 +1,102 @@
+# @patch-target: app.asar.contents/.vite/build/index.js
+# @patch-type: nim
+#
+# Make the built-in agent/Cowork terminal spawn a Linux shell instead of
+# PowerShell.
+#
+# The upstream shell-selection helper is hardcoded to PowerShell on every
+# platform:
+#
+#   function <minified>(){return{shell:"powershell.exe",args:[]}}
+#
+# Its result is fed straight into node-pty's `pty.spawn(shell, args, ...)`
+# inside LocalSessions.startShellPty (and the bash-PTY path). On Linux
+# `powershell.exe` is not on PATH, so spawn-helper's execvp(3) fails and the
+# PTY dies immediately. The renderer shows "Shell exited." and the main log
+# records:
+#
+#   Shell PTY for session local_... exited with code 1
+#
+# (verified: forking `powershell.exe` through the bundled pty.node/spawn-helper
+# yields exactly `execvp(3) failed.: No such file or directory` + exit code 1.)
+#
+# Fix: rewrite ONLY the shell string value into a platform-aware ternary so the
+# user's login shell ($SHELL, falling back to /bin/bash) is used off-Windows.
+# The `args` value and the surrounding function are left untouched.
+#
+# Robustness notes (this pattern is intentionally minimal so it survives
+# upstream re-minification):
+#   - Anchors on `shell:"powershell.exe"` only. The `shell` key is a semantic
+#     node-pty option name (not minified) and "powershell.exe" is the Windows
+#     default shell Anthropic is unlikely to rename.
+#   - Does NOT depend on the (minified, per-release) function name, on the
+#     `args:[]` value, or on any surrounding structure.
+#   - Whitespace- and quote-style-tolerant (`\s*`, `["']`).
+#   - The replacement is Windows-semantics-preserving: on win32 it still
+#     evaluates to "powershell.exe", so even an accidental second match
+#     elsewhere in the bundle stays correct on Windows and sane on Linux.
+#   - `shell:"powershell.exe"` occurs exactly once in the bundle today
+#     (the bare string "powershell.exe" appears 8x, but only here behind a
+#     `shell:` key), so a single match is expected.
+
+import std/[os, strformat, strutils]
+import regex
+
+const EXPECTED_PATCHES = 1
+
+# Platform-aware shell value. On win32 it reproduces the original verbatim;
+# everywhere else it uses the user's login shell with a /bin/bash fallback.
+const SHELL_EXPR =
+  """process.platform==="win32"?"powershell.exe":process.env.SHELL||"/bin/bash""""
+
+# Unique marker proving our replacement is already present (idempotency).
+# "/bin/bash" does not otherwise occur in the upstream bundle.
+const PATCHED_MARKER = """process.env.SHELL||"/bin/bash""""
+
+proc apply*(input: string): string =
+  result = input
+  var patchesApplied = 0
+
+  if PATCHED_MARKER in result:
+    echo "  [INFO] Terminal shell already rewritten for Linux"
+    patchesApplied += 1
+  else:
+    # Group 1: the `shell:` key (with optional whitespace), preserved verbatim.
+    # The remainder (the "powershell.exe" string literal) is replaced.
+    let pattern = re2"""(shell\s*:\s*)["']powershell\.exe["']"""
+
+    var count = 0
+    result = result.replace(
+      pattern,
+      proc(m: RegexMatch2, s: string): string =
+        inc count
+        s[m.group(0)] & SHELL_EXPR,
+    )
+    if count > 0:
+      echo &"  [OK] Terminal shell rewritten to $SHELL/bin/bash: {count} match(es)"
+      patchesApplied += 1
+    else:
+      echo "  [FAIL] Could not find `shell:\"powershell.exe\"` selector"
+      echo "  [HINT] Search for 'powershell.exe' near 'args:[]' (function returning {shell,args})"
+
+  if patchesApplied < EXPECTED_PATCHES:
+    echo &"  [FAIL] Only {patchesApplied}/{EXPECTED_PATCHES} patches applied"
+    quit(1)
+
+when isMainModule:
+  if paramCount() != 1:
+    echo "Usage: fix_terminal_shell_linux <file>"
+    quit(1)
+  let filePath = paramStr(1)
+  echo "=== Patch: fix_terminal_shell_linux ==="
+  echo &"  Target: {filePath}"
+  if not fileExists(filePath):
+    echo &"  [FAIL] File not found: {filePath}"
+    quit(1)
+  let input = readFile(filePath)
+  let output = apply(input)
+  if output != input:
+    writeFile(filePath, output)
+    echo "  [PASS] Terminal shell patched successfully"
+  else:
+    echo "  [PASS] No changes needed (already patched)"


### PR DESCRIPTION
## Problem

The built-in agent/Cowork terminal is unusable on Linux: opening a terminal immediately shows **"Shell exited."** / "Restart shell", and `main.log` records on every attempt:

```
Shell PTY for session local_… exited with code 1
```

Fixes #143.

## Root cause

The shell-selection helper in `index.js` is hardcoded to PowerShell on **every** platform:

```js
function <minified>(){return{shell:"powershell.exe",args:[]}}
```

Its result is passed straight into node-pty's `pty.spawn(shell, args, …)` inside `LocalSessions.startShellPty` (and the bash-PTY path). On Linux `powershell.exe` is not on `PATH`, so `spawn-helper`'s `execvp(3)` fails and the PTY dies instantly.

### Verification

Forking the two shells through the **bundled** `pty.node` + `spawn-helper` (loaded via system Node — N-API, so it loads fine):

```
fork "powershell.exe"  -> code=1  out="execvp(3) failed.: No such file or directory"   <-- exact app error
fork "/bin/bash" []    -> runs fine (code 0)
```

So the native layer (node-pty, spawn-helper, glibc) is correct — only the hardcoded shell string is wrong.

## Fix

Rewrite **only** the shell string value into a platform-aware ternary, leaving the (minified) function name and `args` untouched:

```js
function <minified>(){return{shell:process.platform==="win32"?"powershell.exe":process.env.SHELL||"/bin/bash",args:[]}}
```

### Why this anchor is re-minification resistant

- Matches `(shell\s*:\s*)["']powershell\.exe["']`, which occurs **exactly once** in the bundle. The bare string `powershell.exe` appears 8× elsewhere (Windows-path detection, executable allow-sets), but only here behind a `shell:` key.
- Independent of the per-release minified function name, the `args` value, whitespace, and quote style.
- **Windows-semantics-preserving:** on win32 it still evaluates to `"powershell.exe"`, so even an accidental second match stays correct on Windows and sane on Linux.
- Idempotent via the unique `process.env.SHELL||"/bin/bash"` marker; `EXPECTED_PATCHES = 1` with `quit(1)` on miss (per the repo's patch-strictness rules).

## Testing

Built against the current upstream bundle (**v1.13576.4**) via `build-patched-tarball.sh`:

- ✅ Patch applies: `[OK] Terminal shell rewritten to $SHELL/bin/bash: 1 match(es)`
- ✅ `node --check` passes on the patched `index.js`
- ✅ Idempotent (second run detects already-patched, exit 0)
- ✅ Rewritten shell spawns a working PTY (`/bin/bash`, exit 0 vs. PowerShell's exit 1)
- ✅ Verified in the final RPM bundle: marker present (1×), original `shell:"powershell.exe"` gone

## Changes

- `patches/fix_terminal_shell_linux.nim` — new patch (51 total)
- `README.md` — patch table entry
- `CHANGELOG.md` — dated entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)
