### PR TITLE
Fix StartupWMClass mismatch causing missing GNOME dock icon

### DIFF
--- a/packaging/debian/claude.desktop
+++ b/packaging/debian/claude.desktop
@@ -7,4 +7,4 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;Chat;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=claude
+StartupWMClass=claude-desktop

--- a/packaging/rpm/claude-desktop-bin.spec
+++ b/packaging/rpm/claude-desktop-bin.spec
@@ -100,7 +100,7 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;Chat;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=claude
+StartupWMClass=claude-desktop
 DESKTOP
 
 # Install icon


### PR DESCRIPTION
Fixes the dock/taskbar icon not appearing on GNOME (reported in #148).

Root cause I believe is that the .desktop file declares `StartupWMClass=claude` but the
running app (a native Wayland client launched with --ozone-platform=wayland)
actually reports a wm_class of `claude-desktop` (confirmed via GNOME's
Looking Glass debugger since xprop/X11 tools don't see native Wayland
windows). GNOME Shell uses StartupWMClass to match a running window to its
installed .desktop entry for dock display purposes — since the two strings
didn't match, the match failed and no icon was shown.

Changed StartupWMClass=claude → StartupWMClass=claude-desktop in both the
rpm spec and debian .desktop file, since both contained the identical line.

Tested and verified on Fedora 44 (GNOME, Wayland) confirmed this restores
the dock icon. The debian file was not personally tested cause I don't have an Ubuntu/Debian machine handy right now, but contains the exact same bug so the same fix should apply.