### PR TITLE
README: document Arch Linux ARM's missing edk2-aarch64 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to claude-desktop-bin AUR package will be documented in this
 
 ## 2026-07-01
 
+### README: documented Arch Linux ARM's missing `edk2-aarch64` package (#170)
+
+Arch Linux ARM (and derivatives like EndeavourOS ARM, Manjaro ARM) doesn't carry `edk2-aarch64` in its repos, even though the package is `arch=any` upstream on archlinux.org - so `pacman -S edk2-aarch64` fails with `target not found` on native aarch64 hosts (e.g. Raspberry Pi 5), even after a full `-Syu`. Since the package is architecture-independent, the workaround is to grab it directly from an x86_64 Arch mirror and install it locally with `pacman -U`. Added this note (with the manual-install command) to both Arch Cowork-deps sections in the README.
+
 ### Removed two no-op regression guards (`fix_disable_autoupdate`, `fix_terminal_shell_linux`)
 
 Both patches had become pure no-ops - they mutated nothing and only asserted upstreamed behavior - so they were deleted rather than kept as empty guards. `fix_disable_autoupdate` used to inject a Linux short-circuit into the Squirrel `isInstalled` check; the official `.deb` now bails out of the update manager unless `forceInstalled` (false on our repackaged app), so auto-update is already off. `fix_terminal_shell_linux` used to rewrite a hardcoded `powershell.exe` default into a `$SHELL → /bin/bash → /bin/sh` ternary; the official `.deb` ships a proper POSIX shell resolver and the `powershell.exe` default is gone. Verified against a fresh unpatched v1.17377.1 bundle: both ran to exit 0 with zero byte changes. `PLATFORM_GATE_BASELINE.md` updated.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ sudo pacman -S --needed qemu-system-aarch64 edk2-aarch64 virtiofsd  # aarch64
 # then join the kvm group (once, needs re-login): sudo usermod -aG kvm "$USER"
 ```
 
+> **Arch Linux ARM / EndeavourOS ARM / Manjaro ARM (native aarch64 host, e.g. Raspberry Pi 5):** `edk2-aarch64` is `arch=any` on archlinux.org but Arch Linux ARM's repos don't carry it, so `pacman -S edk2-aarch64` fails with `target not found` even after `-Syu` ([ALARM forum #16140](https://archlinuxarm.org/forum/viewtopic.php?t=16140)). Since the package is architecture-independent, grab it from the x86_64 Arch mirrors and install locally: `curl -O https://geo.mirror.pkgbuild.com/extra/os/x86_64/edk2-aarch64-<version>-any.pkg.tar.zst && sudo pacman -U ./edk2-aarch64-*.pkg.tar.zst` (check [archlinux.org/packages/extra/any/edk2-aarch64](https://archlinux.org/packages/extra/any/edk2-aarch64/) for the current version/filename).
+
 **Computer Use** - pick the line for your session (`echo $XDG_SESSION_TYPE`, `echo $XDG_CURRENT_DESKTOP`):
 
 ```bash
@@ -375,6 +377,7 @@ The Claude Code CLI that Cowork/Dispatch drive is managed by the app itself - no
 > # Fedora/RHEL:   sudo dnf install qemu-system-x86 edk2-ovmf      # arm64: qemu-system-aarch64 edk2-aarch64
 > # Debian/Ubuntu: sudo apt install qemu-system-x86 ovmf           # arm64: qemu-system-arm qemu-efi-aarch64
 > ```
+> On Arch Linux ARM / EndeavourOS ARM / Manjaro ARM (native aarch64 hosts), `edk2-aarch64` is missing from the ALARM repos even though it's `arch=any` upstream - see the Arch install section above for the manual-download workaround.
 
 If the workspace shows "Download failed" and clicking Download does nothing, it's almost always missing `kvm` group membership (or, on AppImage/Nix, missing firmware). **CoworkSpaces** are stored locally per account under `~/.config/Claude/local-agent-mode-sessions/` (see [Known Limitations](#known-limitations)).
 


### PR DESCRIPTION
## Summary
- Root-caused #170: `edk2-aarch64` is `arch=any` on archlinux.org's `extra` repo, but Arch Linux ARM (and derivatives like EndeavourOS ARM, Manjaro ARM) does not carry it in its own repos, so `pacman -S edk2-aarch64` fails with `target not found` on native aarch64 hosts (e.g. Raspberry Pi 5), even after `pacman -Syu` — confirmed against an [ALARM forum report](https://archlinuxarm.org/forum/viewtopic.php?t=16140) of the same problem for QEMU/AAVMF firmware.
- Documented the workaround (manually grabbing the `arch=any` package from an x86_64 Arch mirror and installing with `pacman -U`) in both places the README tells Arch aarch64 users to install `edk2-aarch64`: the AUR "Optional deps" Cowork section, and the AppImage/Nix/source-build firmware note.
- Added a `CHANGELOG.md` entry per project convention.

## Test plan
- [x] Docs-only change; verified the new notes render correctly and match the existing README style/tone.
- [ ] Would benefit from the reporter confirming the manual-install workaround resolves Cowork setup on their EndeavourOS ARM / Raspberry Pi 5 host.

Fixes #170


---
_Generated by [Claude Code](https://claude.ai/code/session_0165hDWjyvsLSuWTqqhjRHM4)_