### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sudo pacman -S --needed qemu-system-aarch64 edk2-aarch64 virtiofsd  # aarch64
 # then join the kvm group (once, needs re-login): sudo usermod -aG kvm "$USER"
 ```
 
-> **Arch Linux ARM / EndeavourOS ARM / Manjaro ARM (native aarch64 host, e.g. Raspberry Pi 5):** `edk2-aarch64` is `arch=any` on archlinux.org but Arch Linux ARM's repos don't carry it, so `pacman -S edk2-aarch64` fails with `target not found` even after `-Syu` ([ALARM forum #16140](https://archlinuxarm.org/forum/viewtopic.php?t=16140)). Since the package is architecture-independent, grab it from the x86_64 Arch mirrors and install locally: `curl -O https://geo.mirror.pkgbuild.com/extra/os/x86_64/edk2-aarch64-<version>-any.pkg.tar.zst && sudo pacman -U ./edk2-aarch64-*.pkg.tar.zst` (check [archlinux.org/packages/extra/any/edk2-aarch64](https://archlinux.org/packages/extra/any/edk2-aarch64/) for the current version/filename).
+> **Arch Linux ARM / EndeavourOS ARM / Manjaro ARM (native aarch64 host, e.g. Raspberry Pi 5):** `edk2-aarch64` is `arch=any` on archlinux.org but Arch Linux ARM's repos don't carry it, so `pacman -S edk2-aarch64` fails with `target not found` even after `-Syu` ([ALARM forum #16140](https://archlinuxarm.org/forum/viewtopic.php?t=16140)). Since the package is architecture-independent, grab it from the x86_64 Arch mirrors and install locally: `curl -L https://archlinux.org/packages/extra/any/edk2-aarch64/download -o edk2-aarch64.pkg.tar.zst && sudo pacman -U ./edk2-aarch64.pkg.tar.zst`.
 
 **Computer Use** - pick the line for your session (`echo $XDG_SESSION_TYPE`, `echo $XDG_CURRENT_DESKTOP`):
 


### PR DESCRIPTION
Change the README.md section for Arch Linux ARM to use a simpler command for downloading the `edk2-aarch64` package.

Instead of requiring users to visit the Arch Linux repository page to determine what to pass to `curl`, the new command downloads the latest version automatically and saves it under a predictable filename for use with `pacman`.