### PR TITLE
RE Computer Use: fail with bridge name + stdout preview on non-JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-desktop-bin AUR package will be documented in this file.
 
+## 2026-07-12
+
+### Computer Use: bridge stdout parsed defensively (clear error instead of bare SyntaxError)
+
+All four bridge invokers (`_x11Bridge`, `_bridge`, `_bridgeAsync` in the regular executor; `execBridgeJson` in the kwin executor) fed bridge stdout straight into `JSON.parse`. A bridge that crashed mid-write, printed a stray warning, or emitted anything but one JSON value surfaced as an anonymous `SyntaxError: Unexpected token` with no hint of which bridge misbehaved or what it printed. Parsing now goes through a guard that fails with the bridge name and a 300-char stdout preview, and the kwin executor also logs the preview to `claude-patches.log` via `__cdbDiag`.
+
 ## 2026-07-11
 
 ### v1.19367.0: upstream code-split the main bundle - orchestrator now patches stub + chunks as one logical file

--- a/js/cu_linux_executor.js
+++ b/js/cu_linux_executor.js
@@ -24,12 +24,22 @@ function _checkYdotool(){if(_ydotoolOk!==null)return _ydotoolOk;if(!_hasCmd("ydo
 // ── x11-bridge: first-party X11/XWayland backend (replaces xdotool/scrot/import/wmctrl) ──
 // The binary is resolved in cu_mode_preamble.js into globalThis.__cuX11BridgeBin.
 function _x11BridgeBin(){return process.env.X11_BRIDGE_BIN||globalThis.__cuX11BridgeBin}
+// Bridges must emit exactly one JSON value on stdout; anything else (crash
+// spew, truncated write, stray warning) lands here. Fail with the bridge name
+// and a stdout preview instead of a bare SyntaxError so the tool result says
+// which bridge misbehaved and what it printed.
+function _parseBridgeJson(label,out){
+  try{return JSON.parse(out)}catch(e){
+    var preview=out.length>300?out.slice(0,300)+"...":out;
+    throw new Error(label+" returned non-JSON output: "+preview);
+  }
+}
 function _x11Bridge(args){
   var bin=_x11BridgeBin();
   if(!bin)throw new Error("x11-bridge not available (globalThis.__cuX11BridgeBin unset — set X11_BRIDGE_BIN or reinstall the package - the bundled bridge is missing)");
   var res=_cp.execFileSync(bin,args,{encoding:"utf-8",timeout:15000,maxBuffer:16*1024*1024});
   var out=res.trim();
-  return out?JSON.parse(out):null;
+  return out?_parseBridgeJson("x11-bridge",out):null;
 }
 // Bridge-side monitor list (RandR names + root-window geometry). Used to map a
 // root-coordinate region to a monitor name + monitor-relative coords for `zoom`.
@@ -48,7 +58,7 @@ function _bridge(bin,args,timeoutMs){
   if(!bin)throw new Error("bridge binary not available");
   var res=_cp.execFileSync(bin,args,{encoding:"utf-8",timeout:timeoutMs||15000,maxBuffer:16*1024*1024});
   var out=res.trim();
-  return out?JSON.parse(out):null;
+  return out?_parseBridgeJson(bin,out):null;
 }
 // Async, non-blocking variant of _bridge. Used ONLY for the GNOME portal
 // session lifecycle (session-start/session-end), because session-start blocks
@@ -61,7 +71,7 @@ function _bridgeAsync(bin,args,timeoutMs){
     _cp.execFile(bin,args,{encoding:"utf-8",timeout:timeoutMs||15000,maxBuffer:16*1024*1024},function(err,stdout){
       if(err){reject(err);return}
       var out=(stdout||"").trim();
-      try{resolve(out?JSON.parse(out):null)}catch(pe){reject(pe)}
+      try{resolve(out?_parseBridgeJson(bin,out):null)}catch(pe){reject(pe)}
     });
   });
 }

--- a/js/executor_linux.js
+++ b/js/executor_linux.js
@@ -141,7 +141,14 @@ async function execBridge(command, args, opts = {}) {
 async function execBridgeJson(command, args, opts) {
   const stdout = await execBridge(command, args, opts)
   if (!stdout) return null
-  const parsed = JSON.parse(stdout)
+  let parsed
+  try {
+    parsed = JSON.parse(stdout)
+  } catch {
+    const preview = stdout.length > 300 ? `${stdout.slice(0, 300)}...` : stdout
+    globalThis.__cdbDiag(`[linux-executor] exec ${command} returned non-JSON`, { preview })
+    throw new Error(`[kwin-portal-bridge] ${command} returned non-JSON output: ${preview}`)
+  }
   debugLog(`exec ${command} parsed json`, {
     type: Array.isArray(parsed) ? 'array' : typeof parsed,
     length: Array.isArray(parsed) ? parsed.length : undefined,


### PR DESCRIPTION
_x11Bridge, _bridge, and _bridgeAsync (regular executor) and execBridgeJson (kwin executor) passed bridge stdout straight to JSON.parse. A bridge that crashed mid-write, printed a warning, or emitted anything but a single JSON value surfaced as a bare "SyntaxError: Unexpected token" with no indication of which bridge misbehaved or what it actually printed.

Route all four sites through a parse guard that throws with the bridge name and a 300-char stdout preview; the kwin executor additionally logs the preview to claude-patches.log via __cdbDiag.

Validated with a full local build: all patches applied, node --check green, and the patched bundle contains the guard at every call site.

Thanks Patrick for your work on this package and the AUR package :heart: Got a few more for the kwin bridge as well but those am still testing so will follow-up later