### PR TITLE
Align Linux app identity to upstream com.anthropic.Claude

### DIFF
--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -82,15 +82,17 @@ package() {
     install -Dm755 "$srcdir/launcher/claude-desktop" "$pkgdir/usr/bin/claude-desktop"
 
     # Install desktop entry.
-    # Filename is "claude-desktop.desktop" to match the live window app_id
-    # "claude-desktop" (Chromium's GetXdgAppId() reads the app's desktopName
-    # "claude-desktop.desktop" from app.asar package.json, strips ".desktop").
-    # On native Wayland there is no WM_CLASS, so KWin/GNOME match by app_id; if
-    # the .desktop basename doesn't equal the app_id the dock icon is generic and
-    # Alt+Tab shows a duplicate (issue #148). StartupWMClass=claude-desktop fixes
-    # the X11/XWayland path. Content mirrors the official Claude Desktop .deb.
+    # Filename is "com.anthropic.Claude.desktop" to match the live window app_id
+    # "com.anthropic.Claude" (Chromium's GetXdgAppId() reads the app's desktopName
+    # "com.anthropic.Claude.desktop" from app.asar package.json, strips ".desktop").
+    # We now ride upstream's official "com.anthropic.Claude" app identity rather
+    # than pinning our own "claude-desktop". On native Wayland there is no
+    # WM_CLASS, so KWin/GNOME match by app_id; if the .desktop basename doesn't
+    # equal the app_id the dock icon is generic and Alt+Tab shows a duplicate
+    # (issue #148). StartupWMClass=com.anthropic.Claude fixes the X11/XWayland
+    # path. Content mirrors the official Claude Desktop .deb.
     install -dm755 "$pkgdir/usr/share/applications"
-    cat > "$pkgdir/usr/share/applications/claude-desktop.desktop" << 'EOF'
+    cat > "$pkgdir/usr/share/applications/com.anthropic.Claude.desktop" << 'EOF'
 [Desktop Entry]
 Name=Claude
 Comment=Desktop application for Claude.ai
@@ -100,7 +102,7 @@ Exec=claude-desktop %U
 Icon=claude-desktop
 Type=Application
 StartupNotify=true
-StartupWMClass=claude-desktop
+StartupWMClass=com.anthropic.Claude
 # second-instance just focuses mainWindow; suppress GNOME's default "New Window" item
 SingleMainWindow=true
 Categories=Utility;Development;

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,145 @@
+# PLAN: Align app identity to upstream `com.anthropic.Claude`
+
+Branch: `align-app-identity-upstream`
+Status: implementation in progress (review target - not for merge until verified on live Wayland)
+
+## Issue
+
+Our build ships a Linux app identity of **`claude-desktop`**, which diverges from
+the identity Anthropic's official `.deb` uses: **`com.anthropic.Claude`**.
+
+The divergence is not a passive fallback - we **actively pin** it. During the
+build, `scripts/build-patched-tarball.sh` rewrites the bundle's
+`package.json` `desktopName` from upstream's `com.anthropic.Claude.desktop` back
+to `claude-desktop.desktop`. Chromium's `GetXdgAppId()` derives a window's
+Wayland `app_id` / X11 `WM_CLASS` from that `desktopName` (when `$CHROME_DESKTOP`
+is unset and no `--class` is passed - both true in our launcher), so the pin is
+what makes every window report `claude-desktop`. Every `.desktop` file, every
+`StartupWMClass`, and the `systemd-run` scope we emit exist to *agree with* that
+pinned value.
+
+Two problems with staying on `claude-desktop`:
+
+1. **It is single-segment (no dots).** The freedesktop / xdg-desktop-portal
+   convention wants a reverse-DNS app id for reliable activation routing and, on
+   KDE, for **persistent** screen-share / Computer Use permission grants. A
+   single-segment id is effectively broken for KDE persistent grants (see the
+   `project_portal_app_identity` project note). `com.anthropic.Claude` is a
+   valid reverse-DNS id - adopting it *fixes* this, it does not just rename it.
+
+2. **It is drift from official for no ongoing benefit.** The pin existed because
+   our `.desktop` machinery (issue #148) was built around `claude-desktop`
+   before upstream shipped its own identity. Now that upstream ships a good
+   reverse-DNS id, riding it removes a whole class of "keep our name and
+   upstream's name in sync" maintenance.
+
+## Goal
+
+Ship the **same app identity as the official build** (`com.anthropic.Claude`)
+across every axis - window `app_id`/`WM_CLASS`, `.desktop` filename,
+`StartupWMClass`, and the `systemd-run` scope - so:
+
+- Wayland dock grouping / Alt-Tab / taskbar pinning match on the upstream id.
+- xdg-desktop-portal activation routing and **KDE persistent permission grants**
+  work (reverse-DNS id).
+- We carry less packaging divergence from upstream.
+
+Non-goals (explicitly out of scope for this change):
+- **Do NOT change `productName`** (stays `Claude`). userData stays
+  `~/.config/Claude` - no data migration, no login loss. This is the hard safety
+  invariant.
+- **Do NOT rename the launcher binary** `/usr/bin/claude-desktop` or the
+  per-profile launcher symlinks `claude-desktop-<name>` - the profile-resolution
+  regex keys off that basename. `Exec=claude-desktop` lines stay.
+- **Do NOT rename the icon** `claude-desktop.png` (`Icon=` is just a theme lookup
+  key, orthogonal to app_id).
+- **Do NOT** try to give each profile a distinct per-profile `app_id` - that
+  needs an unimplemented per-profile `desktopName` override and is a separate
+  effort.
+
+## Solution
+
+One coordinated, atomic change across the identity axes. `productName`, the
+launcher binary name, and the icon are deliberately left alone.
+
+### 1. Remove the pin (root change)
+`scripts/build-patched-tarball.sh`: stop rewriting `desktopName`. Keep an
+adapted tripwire: assert upstream's `desktopName` is still present **and equals
+`com.anthropic.Claude.desktop`** (fail loud if upstream renames again, so our
+fixed `.desktop` filenames can't silently desync a third time).
+
+### 2. Rename the `.desktop` identity everywhere (must move together)
+`claude-desktop.desktop` -> `com.anthropic.Claude.desktop`, and
+`StartupWMClass=claude-desktop` -> `StartupWMClass=com.anthropic.Claude`, in:
+- `scripts/claude-desktop-launcher.sh`: `DESKTOP_ID` base (drives generated
+  `.desktop` filename, `systemd-run` scope middle-token, xdg-mime handler),
+  the two generated-`.desktop` `StartupWMClass` lines, and the two hardcoded
+  `/usr/share/applications/claude-desktop.desktop` lookups (`_create_profile`
+  source-inherit, `_diagnose` portal anchor).
+- `packaging/debian/` (`build-deb.sh` heredoc + `claude-desktop.desktop`
+  committed file + `rules` install line).
+- `packaging/rpm/claude-desktop-bin.spec` (heredoc target, StartupWMClass,
+  `%files` entry).
+- `packaging/appimage/build-appimage.sh` (AppDir `.desktop` + StartupWMClass +
+  copy into `usr/share/applications/`; appimagetool needs the AppDir `.desktop`
+  basename == AppRun/binary name - handle carefully).
+- `packaging/nix/package.nix` (`makeDesktopItem name=` and `startupWMClass`).
+- `PKGBUILD.template` (AUR `.desktop` heredoc + StartupWMClass).
+
+`Exec=` lines keep pointing at the launcher binary `claude-desktop` (unchanged).
+
+### 3. Keep `fix_quick_entry_app_id.nim` as-is (already alignment-ready)
+Its reset already reads `desktopName` from `package.json` at runtime, so with
+the pin gone it naturally resolves to `com.anthropic.Claude` - and its fallback
+literal is already `com.anthropic.Claude`. The QE window's own distinct id
+`claude-quick-entry` stays (our value-add). No patch drops; only the comments
+become accurate. No complexity reduction is safe (the runtime read is what
+survives future upstream renames - keep it).
+
+### 4. Backward-compat for existing installs (mitigation)
+- **Launcher source-inherit + portal-anchor lookups now probe BOTH names**
+  (new `com.anthropic.Claude.desktop` first, legacy `claude-desktop.desktop`
+  fallback) - implemented at launcher `_create_profile` source-inherit and
+  `_diagnose` portal anchor. So a profile created on a not-yet-upgraded install
+  still resolves.
+- **Per-profile `.desktop` renamed to `com.anthropic.Claude-<name>.desktop`**
+  in `_profile_paths` + `_create_profile`; `_delete_profile` removes BOTH the
+  new and legacy (`claude-desktop-<name>.desktop`) names so old profiles clean
+  up fully. IMPLEMENTED.
+- **Still open (reviewer decision):** default-profile pinned taskbar shortcuts
+  referencing the old `claude-desktop.desktop` will orphan on upgrade. A
+  compat symlink from the old name -> new is NOT yet shipped (would live in each
+  packager's install step). Users re-pin once; documented as a one-time break.
+  Decide whether to add the symlink or just document.
+
+## Risks (reviewer: verify these on live Wayland before trusting the change)
+
+1. **All-or-nothing.** A partial rename (pin removed but one packager's `.desktop`
+   still `claude-desktop.desktop`) is a **silent** Wayland dock regression - the
+   build passes, only a live Wayland session shows the generic-icon / duplicate
+   Alt-Tab symptom (issue #148, inverted). Every axis in step 2 must land together.
+2. **Pinned-shortcut orphaning** for existing users (step 4 mitigation).
+3. **Stale per-profile `.desktop` files** for users who already made profiles.
+4. **systemd scope with a dotted middle-token**
+   (`app-com.anthropic.Claude-$$.scope`) - follows the freedesktop convention
+   (Flatpak/GNOME do this) but was not live-exercised; verify `systemd-run
+   --unit=` accepts it here.
+5. **Per-profile distinct app_id is still unsolved** - not in scope; don't expect
+   per-profile icons from this change.
+
+## Verification checklist (for review over the coming days)
+
+- [ ] Build each package format; grep the built `.desktop` + bundle `desktopName`
+      all report `com.anthropic.Claude`.
+- [ ] KDE Plasma Wayland: main window `resourceClass = com.anthropic.Claude`,
+      Quick Entry = `claude-quick-entry`, dock grouping correct.
+      (`scripts/diagnose-window-appid.sh`)
+- [ ] GNOME Wayland: same via Window Calls.
+- [ ] X11/XWayland: `WM_CLASS = com.anthropic.Claude`, taskbar grouping correct.
+- [ ] Computer Use screen-share consent on KDE **persists** across restarts
+      (the concrete payoff of the reverse-DNS id).
+- [ ] `claude://` link still opens the app (xdg-mime handler renamed).
+- [ ] Named profile: `--create-profile work`, launch, confirm it still works and
+      old stale `.desktop` (if any) is handled.
+- [ ] Existing pinned taskbar shortcut from the old name still launches (compat).
+- [ ] userData still `~/.config/Claude` (unchanged) - no re-login.

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -161,16 +161,17 @@ EOF
 chmod +x "$APPDIR/AppRun"
 
 # Create desktop file.
-# Filename is "claude-desktop.desktop" to match the live window app_id
-# "claude-desktop" (Chromium's GetXdgAppId() reads the app's desktopName
-# "claude-desktop.desktop" from app.asar, strips ".desktop"). appimagetool also
-# matches the AppDir-root .desktop basename to the icon/app id, so the root copy
-# must be claude-desktop.desktop too. On native Wayland there is no WM_CLASS, so
-# KWin/GNOME match by app_id; a mismatched basename gives a generic icon +
-# Alt+Tab duplicate (issue #148). Content mirrors the official Claude Desktop .deb.
+# Filename is "com.anthropic.Claude.desktop" to match the live window app_id
+# "com.anthropic.Claude" (Chromium's GetXdgAppId() reads the app's desktopName
+# "com.anthropic.Claude.desktop" from app.asar - upstream's own - and strips
+# ".desktop"; we no longer pin our own). appimagetool matches the AppDir-root
+# .desktop's Icon= to an icon file at the root (claude-desktop.png, unchanged),
+# so the .desktop filename and the Icon= name are independent. On native Wayland
+# there is no WM_CLASS, so KWin/GNOME match by app_id; a mismatched basename gives
+# a generic icon + Alt+Tab duplicate (issue #148). Content mirrors the official .deb.
 log_info "Creating desktop file..."
 mkdir -p "$APPDIR/usr/share/applications"
-cat > "$APPDIR/claude-desktop.desktop" << EOF
+cat > "$APPDIR/com.anthropic.Claude.desktop" << EOF
 [Desktop Entry]
 Name=Claude
 Comment=Desktop application for Claude.ai
@@ -180,7 +181,7 @@ Exec=claude-desktop %U
 Icon=claude-desktop
 Type=Application
 StartupNotify=true
-StartupWMClass=claude-desktop
+StartupWMClass=com.anthropic.Claude
 # second-instance just focuses mainWindow; suppress GNOME's default "New Window" item
 SingleMainWindow=true
 Categories=Utility;Development;
@@ -196,7 +197,7 @@ Exec=claude-desktop claude://claude.ai/new
 Name=New Claude Code session
 Exec=claude-desktop claude://code/new
 EOF
-cp "$APPDIR/claude-desktop.desktop" "$APPDIR/usr/share/applications/"
+cp "$APPDIR/com.anthropic.Claude.desktop" "$APPDIR/usr/share/applications/"
 
 # Copy icon
 log_info "Installing icon..."

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -123,13 +123,13 @@ fi
 install -m755 "$WORK_DIR/tarball/launcher/claude-desktop" "$DEB_ROOT/usr/bin/claude-desktop"
 
 # Install desktop file.
-# Filename is "claude-desktop.desktop" to match the live window app_id
-# "claude-desktop" (Chromium's GetXdgAppId() reads the app's desktopName
-# "claude-desktop.desktop" from app.asar, strips ".desktop"). On native Wayland
-# there is no WM_CLASS, so KWin/GNOME match by app_id; a mismatched basename gives
-# a generic icon + Alt+Tab duplicate (issue #148). StartupWMClass fixes X11.
+# Filename is "com.anthropic.Claude.desktop" to ride upstream's app identity
+# "com.anthropic.Claude" (Chromium's GetXdgAppId() reads the app's desktopName,
+# now "com.anthropic.Claude.desktop", and strips ".desktop"); we no longer pin it.
+# On native Wayland there is no WM_CLASS, so KWin/GNOME match by app_id; a mismatched
+# basename gives a generic icon + Alt+Tab duplicate (issue #148). StartupWMClass fixes X11.
 # Content mirrors the official Claude Desktop .deb.
-cat > "$DEB_ROOT/usr/share/applications/claude-desktop.desktop" << 'EOF'
+cat > "$DEB_ROOT/usr/share/applications/com.anthropic.Claude.desktop" << 'EOF'
 [Desktop Entry]
 Name=Claude
 Comment=Desktop application for Claude.ai
@@ -139,7 +139,7 @@ Exec=claude-desktop %U
 Icon=claude-desktop
 Type=Application
 StartupNotify=true
-StartupWMClass=claude-desktop
+StartupWMClass=com.anthropic.Claude
 # second-instance just focuses mainWindow; suppress GNOME's default "New Window" item
 SingleMainWindow=true
 Categories=Utility;Development;

--- a/packaging/debian/com.anthropic.Claude.desktop
+++ b/packaging/debian/com.anthropic.Claude.desktop
@@ -7,7 +7,7 @@ Exec=claude-desktop %U
 Icon=claude-desktop
 Type=Application
 StartupNotify=true
-StartupWMClass=claude-desktop
+StartupWMClass=com.anthropic.Claude
 # second-instance just focuses mainWindow; suppress GNOME's default "New Window" item
 SingleMainWindow=true
 Categories=Utility;Development;

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -18,10 +18,10 @@ override_dh_auto_install:
 	install -d debian/claude-desktop/usr/bin
 	install -m755 launcher/claude-desktop debian/claude-desktop/usr/bin/claude-desktop
 
-	# Install desktop file (basename must match the live app_id "claude-desktop"
-	# so native-Wayland WMs bind the dock icon; see issue #148)
+	# Install desktop file (basename must match upstream's app identity
+	# "com.anthropic.Claude" so native-Wayland WMs bind the dock icon; see issue #148)
 	install -d debian/claude-desktop/usr/share/applications
-	install -m644 debian/claude-desktop.desktop debian/claude-desktop/usr/share/applications/
+	install -m644 debian/com.anthropic.Claude.desktop debian/claude-desktop/usr/share/applications/
 
 	# Install icon
 	install -d debian/claude-desktop/usr/share/icons/hicolor/256x256/apps

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -73,19 +73,23 @@ stdenvNoCC.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper copyDesktopItems ];
 
-  # "name" becomes the .desktop filename. It is "claude-desktop" so the installed
-  # file is claude-desktop.desktop, matching the app's *live* app_id - Chromium's
-  # GetXdgAppId() reads the app's desktopName ("claude-desktop.desktop" in
+  # "name" becomes the .desktop filename. It is "com.anthropic.Claude" so the
+  # installed file is com.anthropic.Claude.desktop, matching the app's *live*
+  # app_id - Chromium's GetXdgAppId() reads the app's desktopName
+  # ("com.anthropic.Claude.desktop" in
   # app.asar package.json), strips ".desktop", and ignores the binary basename
-  # / --class / argv[0]. On native Wayland there is no WM_CLASS, so KWin/GNOME
-  # match the window to its .desktop by app_id; if the basename doesn't equal the
-  # app_id the dock icon is generic and Alt+Tab shows a duplicate (issue #148).
-  # startupWMClass=claude-desktop fixes the X11/XWayland path. The binary rename
-  # below is kept only as a cosmetic argv[0] / scope hint; it does NOT set
-  # WM_CLASS. Content mirrors the official Claude Desktop .deb.
+  # / --class / argv[0]. We now ride upstream's official "com.anthropic.Claude"
+  # app identity, so the .desktop filename and startupWMClass match it (we no
+  # longer pin our own "claude-desktop" identity). On native Wayland there is no
+  # WM_CLASS, so KWin/GNOME match the window to its .desktop by app_id; if the
+  # basename doesn't equal the app_id the dock icon is generic and Alt+Tab shows
+  # a duplicate (issue #148). startupWMClass=com.anthropic.Claude fixes the
+  # X11/XWayland path. The claude-desktop binary rename below is kept only as a
+  # cosmetic argv[0] / scope hint; it does NOT set WM_CLASS. Content mirrors the
+  # official Claude Desktop .deb.
   desktopItems = [
     (makeDesktopItem {
-      name = "claude-desktop";
+      name = "com.anthropic.Claude";
       desktopName = "Claude";
       genericName = "AI Assistant";
       comment = "Desktop application for Claude.ai";
@@ -95,7 +99,7 @@ stdenvNoCC.mkDerivation {
       categories = [ "Utility" "Development" ];
       mimeTypes = [ "x-scheme-handler/claude" ];
       startupNotify = true;
-      startupWMClass = "claude-desktop";
+      startupWMClass = "com.anthropic.Claude";
       terminal = false;
       # second-instance just focuses mainWindow; suppress GNOME's "New Window" item
       singleMainWindow = true;
@@ -118,7 +122,7 @@ stdenvNoCC.mkDerivation {
     # Materialise the nixpkgs Electron dist into $out/lib/claude-desktop/ with the
     # binary renamed to "claude" (cosmetic argv[0] / systemd-scope hint only; the
     # Wayland app_id / X11 WM_CLASS comes from the app's desktopName
-    # "claude-desktop", not this basename - see startupWMClass above). The
+    # "com.anthropic.Claude", not this basename - see startupWMClass above). The
     # tarball's own bundled Electron runtime is DISCARDED on NixOS (foreign
     # glibc); we use nixpkgs electron instead.
     mkdir -p $out/lib/claude-desktop

--- a/packaging/rpm/claude-desktop-bin.spec
+++ b/packaging/rpm/claude-desktop-bin.spec
@@ -130,14 +130,14 @@ install -m755 tarball/launcher/claude-desktop %{buildroot}/usr/bin/claude-deskto
 install -Dm644 tarball/copyright %{buildroot}/usr/share/licenses/%{name}/copyright
 
 # Install desktop file.
-# Filename is "claude-desktop.desktop" to match the live window app_id
-# "claude-desktop" (Chromium's GetXdgAppId() reads the app's desktopName
-# "claude-desktop.desktop" from app.asar, strips ".desktop"). On native Wayland
-# there is no WM_CLASS, so KWin/GNOME match by app_id; a mismatched basename gives
-# a generic icon + Alt+Tab duplicate (issue #148). StartupWMClass fixes X11.
+# Filename is "com.anthropic.Claude.desktop" to ride upstream's app identity
+# "com.anthropic.Claude" (Chromium's GetXdgAppId() reads the app's desktopName,
+# now "com.anthropic.Claude.desktop", and strips ".desktop"); we no longer pin it.
+# On native Wayland there is no WM_CLASS, so KWin/GNOME match by app_id; a mismatched
+# basename gives a generic icon + Alt+Tab duplicate (issue #148). StartupWMClass fixes X11.
 # Content mirrors the official Claude Desktop .deb.
 mkdir -p %{buildroot}/usr/share/applications
-cat > %{buildroot}/usr/share/applications/claude-desktop.desktop << 'DESKTOP'
+cat > %{buildroot}/usr/share/applications/com.anthropic.Claude.desktop << 'DESKTOP'
 [Desktop Entry]
 Name=Claude
 Comment=Desktop application for Claude.ai
@@ -147,7 +147,7 @@ Exec=claude-desktop %U
 Icon=claude-desktop
 Type=Application
 StartupNotify=true
-StartupWMClass=claude-desktop
+StartupWMClass=com.anthropic.Claude
 # second-instance just focuses mainWindow; suppress GNOME's default "New Window" item
 SingleMainWindow=true
 Categories=Utility;Development;
@@ -230,5 +230,5 @@ fi
 %license /usr/share/licenses/%{name}/copyright
 /usr/lib/claude-desktop/
 /usr/bin/claude-desktop
-/usr/share/applications/claude-desktop.desktop
+/usr/share/applications/com.anthropic.Claude.desktop
 /usr/share/icons/hicolor/256x256/apps/claude-desktop.png

--- a/scripts/build-patched-tarball.sh
+++ b/scripts/build-patched-tarball.sh
@@ -301,32 +301,25 @@ APP_DIR="$WORK_DIR/app"
 mkdir -p "$APP_DIR"
 asar extract "$TREE_DIR/resources/app.asar" "$APP_DIR/app.asar.contents"
 
-# App identity: pin desktopName to "claude-desktop.desktop". Chromium derives the
-# window's Wayland app_id / X11 WM_CLASS from package.json desktopName, and every
-# .desktop file we ship (deb/rpm/AUR/AppImage/Nix, plus the launcher's per-profile
-# entries, StartupWMClass and the claude:// xdg-mime handler) is built around the
-# "claude-desktop" identity (issue #148). Upstream v1.19367.0 renamed its
-# desktopName to com.anthropic.Claude.desktop for the .desktop file the official
-# .deb installs - a file we do not ship. The JS bundle contains no reference to
-# either name, so pinning is safe; without it, window/icon matching silently
-# breaks on Wayland.
-log_info "Pinning desktopName app identity..."
+# App identity: we ride upstream's own desktopName ("com.anthropic.Claude.desktop")
+# rather than pinning our own. Chromium derives the window's Wayland app_id / X11
+# WM_CLASS from package.json desktopName (GetXdgAppId, when $CHROME_DESKTOP is
+# unset and no --class is passed - both true in our launcher). Every .desktop file
+# we ship (deb/rpm/AUR/AppImage/Nix, the launcher's per-profile entries,
+# StartupWMClass, and the claude:// xdg-mime handler) is built around that same
+# "com.anthropic.Claude" identity, so window/icon matching and xdg-desktop-portal
+# activation routing agree on the upstream reverse-DNS id (which, unlike the old
+# single-segment "claude-desktop", also lets KDE persist Computer Use grants).
+# We do NOT touch productName ("Claude"), so userData stays ~/.config/Claude.
+# This tripwire fails loud if upstream renames desktopName again, so our fixed
+# .desktop filenames cannot silently desync from the live window app_id.
+log_info "Asserting upstream desktopName app identity..."
 PKG_JSON="$APP_DIR/app.asar.contents/package.json"
-if ! grep -q '"desktopName"' "$PKG_JSON"; then
-    log_error "package.json has no desktopName key - upstream changed app-identity handling; re-audit (launcher APP_ID/DESKTOP_ID header)"
+if ! grep -q '"desktopName": *"com.anthropic.Claude.desktop"' "$PKG_JSON"; then
+    log_error "package.json desktopName is not \"com.anthropic.Claude.desktop\" - upstream changed the app identity; re-audit the .desktop filenames + StartupWMClass + launcher DESKTOP_ID (see PLAN.md / launcher APP_ID/DESKTOP_ID header)"
     exit 1
 fi
-python3 - "$PKG_JSON" <<'PYEOF'
-import json, sys
-p = sys.argv[1]
-with open(p) as f:
-    d = json.load(f)
-d["desktopName"] = "claude-desktop.desktop"
-with open(p, "w") as f:
-    json.dump(d, f, indent=2)
-PYEOF
-grep -q '"desktopName": "claude-desktop.desktop"' "$PKG_JSON" || { log_error "desktopName pin failed"; exit 1; }
-log_info "desktopName pinned to claude-desktop.desktop"
+log_info "desktopName is upstream com.anthropic.Claude.desktop (no pin)"
 
 # Compile Nim patches (native build or Docker fallback)
 log_info "Compiling Nim patches..."

--- a/scripts/claude-desktop-launcher.sh
+++ b/scripts/claude-desktop-launcher.sh
@@ -37,22 +37,22 @@ set -euo pipefail
 # Launch section).
 #
 # IMPORTANT: APP_ID is NOT the window's WM_CLASS / Wayland app_id either. That
-# value is "claude-desktop" (verified via xprop/wmctrl) and comes from
+# value is "com.anthropic.Claude" (verified via xprop/wmctrl) and comes from
 # Chromium's GetXdgAppId(), which reads the app's desktopName
-# ("claude-desktop.desktop" in app.asar package.json) and ignores the binary
-# basename / --class / argv[0].
-APP_ID='claude'
+# ("com.anthropic.Claude.desktop" in app.asar package.json - upstream's own) and
+# ignores the binary basename / --class / argv[0].
 
 # The .desktop filename is a SEPARATE identity (DESKTOP_ID), computed below once
-# the profile is known. As of issue #148 the default-profile launcher ships as
-# "claude-desktop.desktop" so the filename equals the window's Wayland app_id
-# ("claude-desktop"). On native Wayland there is no WM_CLASS, so GNOME/KDE match
-# the window to its .desktop entry by app_id == .desktop filename; the old
-# "claude.desktop" never matched and the dock/Alt-Tab icon fell back to a generic
-# one. StartupWMClass (also "claude-desktop", set in every .desktop we write)
-# covers X11/XWayland. So now BOTH match keys agree: filename == app_id (Wayland)
-# and StartupWMClass == app_id (X11). See the DESKTOP_ID assignment after profile
-# resolution below.
+# the profile is known. The default-profile launcher ships as
+# "com.anthropic.Claude.desktop" so the filename equals the window's Wayland
+# app_id ("com.anthropic.Claude"). On native Wayland there is no WM_CLASS, so
+# GNOME/KDE match the window to its .desktop entry by app_id == .desktop filename;
+# a mismatched filename makes the dock/Alt-Tab icon fall back to a generic one
+# (issue #148). StartupWMClass (also "com.anthropic.Claude", set in every .desktop
+# we write) covers X11/XWayland. So BOTH match keys agree: filename == app_id
+# (Wayland) and StartupWMClass == app_id (X11). The reverse-DNS id also lets
+# xdg-desktop-portal persist Computer Use grants on KDE. See the DESKTOP_ID
+# assignment after profile resolution below.
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -185,9 +185,9 @@ fi
 config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/Claude${profile_suffix}"
 
 # .desktop filename identity (see the DESKTOP_ID note in the APP_ID header).
-# Default profile → "claude-desktop"; named profile → "claude-desktop-<name>".
+# Default profile → "com.anthropic.Claude"; named → "com.anthropic.Claude-<name>".
 # Distinct from APP_ID (the cosmetic binary/scope basename, still "claude").
-DESKTOP_ID="claude-desktop${profile_suffix}"
+DESKTOP_ID="com.anthropic.Claude${profile_suffix}"
 
 # ---------------------------------------------------------------------------
 # URL handler profile routing (SSO callback dispatch)
@@ -462,10 +462,13 @@ print(repr(arr))
 _profile_paths() {
     # Outputs the four files associated with a profile to stdout, one per line.
     # Order: electron-symlink, launcher-symlink, desktop-file, config-dir.
+    # The .desktop filename is the app IDENTITY (com.anthropic.Claude-<name>),
+    # NOT the launcher-binary/symlink name (claude-desktop-<name>) - those are
+    # deliberately different axes (see the APP_ID / DESKTOP_ID header).
     local name="$1"
     echo "$HOME/.local/lib/claude-desktop/${APP_ID}-${name}"
     echo "$HOME/.local/bin/claude-desktop-${name}"
-    echo "$HOME/.local/share/applications/claude-desktop-${name}.desktop"
+    echo "$HOME/.local/share/applications/com.anthropic.Claude-${name}.desktop"
     echo "${XDG_CONFIG_HOME:-$HOME/.config}/Claude-${name}"
 }
 
@@ -652,7 +655,7 @@ ${desired_exec}
 Icon=claude-desktop
 Type=Application
 StartupNotify=true
-StartupWMClass=claude-desktop
+StartupWMClass=com.anthropic.Claude
 SingleMainWindow=true
 Categories=Utility;Development;
 MimeType=x-scheme-handler/claude;
@@ -764,7 +767,7 @@ _create_profile() {
 
     local electron_bin_path="$HOME/.local/lib/claude-desktop/${APP_ID}-${name}"
     local launcher_link="$HOME/.local/bin/claude-desktop-${name}"
-    local desktop_file="$HOME/.local/share/applications/claude-desktop-${name}.desktop"
+    local desktop_file="$HOME/.local/share/applications/com.anthropic.Claude-${name}.desktop"
 
     if [[ -e "$electron_bin_path" || -e "$launcher_link" || -e "$desktop_file" ]]; then
         echo >&2 "claude-desktop: profile '$name' already exists. Use --delete-profile=$name first to recreate."
@@ -803,10 +806,14 @@ _create_profile() {
     ln -s "$launcher_path" "$launcher_link"
 
     # Try to find the default-profile system .desktop to inherit Icon=, etc.
-    # The installed default file is "claude-desktop.desktop" (issue #148), not
-    # "${APP_ID}.desktop" - APP_ID is now only the binary/scope basename.
+    # The installed default file is "com.anthropic.Claude.desktop" (upstream's
+    # own identity), not "${APP_ID}.desktop" - APP_ID is only the binary/scope
+    # basename. The legacy "claude-desktop.desktop" name is also probed so a
+    # profile created on a not-yet-upgraded install still finds a source.
     local source_desktop=""
     for c in \
+        "/usr/share/applications/com.anthropic.Claude.desktop" \
+        "$HOME/.local/share/applications/com.anthropic.Claude.desktop" \
         "/usr/share/applications/claude-desktop.desktop" \
         "$HOME/.local/share/applications/claude-desktop.desktop"; do
         if [[ -f "$c" ]]; then
@@ -855,7 +862,7 @@ ${exec_line}
 Terminal=false
 Type=Application
 Icon=claude-desktop
-StartupWMClass=claude-desktop
+StartupWMClass=com.anthropic.Claude
 Categories=Utility;Development;
 EOF
     fi
@@ -890,10 +897,13 @@ _delete_profile() {
 
     local electron_link="$HOME/.local/lib/claude-desktop/${APP_ID}-${name}"
     local launcher_link="$HOME/.local/bin/claude-desktop-${name}"
-    local desktop_file="$HOME/.local/share/applications/claude-desktop-${name}.desktop"
+    local desktop_file="$HOME/.local/share/applications/com.anthropic.Claude-${name}.desktop"
+    # Legacy per-profile .desktop name from before the app-identity alignment;
+    # removed too so profiles created by an older launcher clean up fully.
+    local legacy_desktop_file="$HOME/.local/share/applications/claude-desktop-${name}.desktop"
 
     local removed=0
-    for f in "$electron_link" "$launcher_link" "$desktop_file"; do
+    for f in "$electron_link" "$launcher_link" "$desktop_file" "$legacy_desktop_file"; do
         if [[ -L "$f" || -f "$f" ]]; then
             rm -f "$f"
             echo "Removed: $f"
@@ -989,10 +999,11 @@ _diagnose() {
     echo "config_dir = $config_dir"
     echo "DESKTOP_ID = $DESKTOP_ID"
     # The system-installed default .desktop is the portal-identity anchor that
-    # the systemd scope (app-claude-...scope) resolves back to. It is always the
-    # default "claude-desktop.desktop" (issue #148); named-profile .desktop files
-    # live user-local under ~/.local/share/applications/claude-desktop-<name>.desktop.
-    local desktop_file="/usr/share/applications/claude-desktop.desktop"
+    # the systemd scope (app-com.anthropic.Claude-...scope) resolves back to. It
+    # is the default "com.anthropic.Claude.desktop"; named-profile .desktop files
+    # live user-local under ~/.local/share/applications/com.anthropic.Claude-<name>.desktop.
+    local desktop_file="/usr/share/applications/com.anthropic.Claude.desktop"
+    [[ -f $desktop_file ]] || desktop_file="/usr/share/applications/claude-desktop.desktop"
     if [[ -f $desktop_file ]]; then
         echo ".desktop file: $desktop_file (found)"
     else
@@ -1665,8 +1676,9 @@ log "Launching: $ELECTRON_BIN (auto-loads $APP_ASAR) ${ELECTRON_ARGS[*]} $*"
 # app-${DESKTOP_ID}-PID.scope) is the identity signal xdg-desktop-portal uses to
 # resolve us back to our .desktop. By the freedesktop convention the middle
 # token is the application id == .desktop basename, so it must be DESKTOP_ID
-# ("claude-desktop"), NOT APP_ID ("claude") - otherwise the portal would look
-# for the now-renamed "claude.desktop" and fail to identify us (issue #148).
+# ("com.anthropic.Claude"), NOT APP_ID ("claude"). The reverse-DNS id (with dots)
+# is what lets the portal persist Computer Use grants on KDE; the scope unit
+# app-com.anthropic.Claude-PID.scope follows the same convention Flatpak/GNOME use.
 # This is separate from the window app_id / X11 WM_CLASS ("claude-desktop", from
 # the app's desktopName); that dock-icon match uses StartupWMClass / the .desktop
 # filename instead. APP_ID remains only the cosmetic Electron binary basename.


### PR DESCRIPTION
## Summary

Stop pinning our own `claude-desktop` app identity and ride the official build's `com.anthropic.Claude` instead. Full rationale, risks, and a verification checklist are in **[PLAN.md](PLAN.md)** on this branch.

**This is a review branch - do not merge until verified on live Wayland** (KDE + GNOME) per the PLAN.md checklist. Opened as a PR so it can be reviewed over the coming days.

## What changes

- **Root:** `build-patched-tarball.sh` no longer rewrites `package.json` `desktopName`; it now *asserts* upstream's value is still `com.anthropic.Claude.desktop` (fail-loud tripwire). Chromium derives the window app_id from `desktopName`, so the live window becomes `com.anthropic.Claude`.
- **Identity renamed on every axis to agree:** launcher `DESKTOP_ID` (.desktop filename + systemd-run scope token + xdg-mime handler), `StartupWMClass`, per-profile `.desktop` naming, and all packaging (deb / rpm / appimage / nix / AUR).

## Deliberately unchanged (separate axes)

- `productName` = `Claude` -> **userData stays `~/.config/Claude`, no data migration, no re-login**.
- Launcher binary `/usr/bin/claude-desktop` + per-profile symlinks `claude-desktop-<name>` (profile-resolution keys off them), `Exec=` lines, and the icon `claude-desktop.png`.

## Breaking change (one-time, cosmetic/config only - NO data loss)

1. **Pinned taskbar/dock shortcuts** referencing `claude-desktop.desktop` orphan -> **re-pin once**.
2. **Custom WM rules / GNOME-extension blacklists** matching `claude-desktop` (app_id/WM_CLASS) must switch to `com.anthropic.Claude` (named profiles keep `com.anthropic.Claude-<name>`).
3. **Existing named profiles**: old `claude-desktop-<name>.desktop` -> `_delete_profile` now cleans both old and new names.

Backward-compat: launcher source-inherit + portal-anchor lookups probe the new name first, fall back to legacy `claude-desktop.desktop`. A default-profile compat symlink (old -> new) is **not yet shipped** - reviewer decision (see PLAN.md step 4).

## Why

`com.anthropic.Claude` is a valid reverse-DNS id, which (unlike single-segment `claude-desktop`) lets xdg-desktop-portal **persist Computer Use grants on KDE**, and reduces divergence from the official `.deb`.

## Verification checklist (see PLAN.md)

- [ ] Built `.desktop` + bundle `desktopName` all report `com.anthropic.Claude` (every format)
- [ ] KDE Wayland: main window `com.anthropic.Claude`, Quick Entry `claude-quick-entry`, dock grouping correct (`scripts/diagnose-window-appid.sh`)
- [ ] GNOME Wayland: same
- [ ] X11/XWayland: `WM_CLASS = com.anthropic.Claude`
- [ ] KDE Computer Use screen-share consent **persists** across restarts (the payoff)
- [ ] `claude://` link still opens the app
- [ ] Named profile create/launch/delete works; stale old `.desktop` cleaned
- [ ] userData still `~/.config/Claude` (no re-login)

## Notes

- CHANGELOG entry deferred to merge time (avoids conflict with master's daily entry; not final until verified).
- `fix_quick_entry_app_id` needs no change - it already reads `desktopName` at runtime; no `.nim` patch drops.