### PR TITLE
Fix two CodeQL finding classes: URL substring gates and entity decoding

### DIFF
--- a/js/diff_views_main.js
+++ b/js/diff_views_main.js
@@ -2430,7 +2430,7 @@
     wc.on("dom-ready", function () {
       try {
         var url = wc.getURL() || "";
-        if (url.indexOf("claude.ai") !== -1 || url.indexOf("claude.com") !== -1) {
+        if (originAllowed(url)) {
           wc.executeJavaScript(PAGE_SRC).catch(function () {});
         }
       } catch (e) {}

--- a/js/panel_tabs_main.js
+++ b/js/panel_tabs_main.js
@@ -209,18 +209,23 @@
   // no bridge present the page degrades silently (no throw, no warn spam,
   // feature off) - this handler is what makes it live at all.
   //
-  // The URL test here is a plain substring check, same posture as the sibling
-  // diff-views injection site: it only decides whether to bother running
-  // executeJavaScript on this webContents, it is NOT a security boundary (the
-  // page script itself does nothing sensitive - it only defines globals and
-  // polls state(), which re-validates the sender origin strictly, above). A
-  // false-positive match here would at most waste one executeJavaScript call
-  // on an unrelated page.
+  // The URL test here only decides whether to bother running executeJavaScript
+  // on this webContents, it is NOT a security boundary (the page script itself
+  // does nothing sensitive - it only defines globals and polls state(), which
+  // re-validates the sender origin strictly, above). It is looser than
+  // ALLOWED_ORIGINS on purpose: any claude.ai/claude.com subdomain gets the
+  // injection, so an upstream move to another subdomain does not kill the bar.
+  function injectHost(rawUrl) {
+    var host;
+    try { host = new _URL(String(rawUrl)).hostname; } catch (e) { return false; }
+    return host === "claude.ai" || host.endsWith(".claude.ai") ||
+      host === "claude.com" || host.endsWith(".claude.com");
+  }
   _app.on("web-contents-created", function (_ev, wc) {
     wc.on("dom-ready", function () {
       try {
         var url = (wc.getURL && wc.getURL()) || "";
-        if (url.indexOf("claude.ai") !== -1 || url.indexOf("claude.com") !== -1) {
+        if (injectHost(url)) {
           wc.executeJavaScript(PAGE_SRC).catch(function () {});
         }
       } catch (e) {}

--- a/scripts/tests/community/test-diff-views-expand-dom.mjs
+++ b/scripts/tests/community/test-diff-views-expand-dom.mjs
@@ -46,6 +46,7 @@ import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { unescapeHtml } from "../lib/unescape-html.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const EXPAND_JS = readFileSync(join(ROOT, "js/diff_views_expand.js"), "utf8");
@@ -887,7 +888,7 @@ for (const [name, fx, run, font] of scenarios) {
     continue;
   }
   const lines = m[1].split("\n").filter(Boolean)
-    .map((l) => l.replace(/&quot;/g, '"').replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">"));
+    .map(unescapeHtml);
   let n = 0;
   let s = 0;
   for (const line of lines) {

--- a/scripts/tests/community/test-panel-tabs-dom.mjs
+++ b/scripts/tests/community/test-panel-tabs-dom.mjs
@@ -36,6 +36,7 @@ import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { unescapeHtml } from "../lib/unescape-html.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const SRC = (f) => readFileSync(join(ROOT, "js/" + f), "utf8");
@@ -366,8 +367,7 @@ function run(html, name, budgetMs) {
       "--virtual-time-budget=" + (budgetMs || 2000), "--dump-dom", "file://" + file], { encoding: "utf8" });
     const m = dom.match(/<pre id="__result">([\s\S]*?)<\/pre>/);
     if (!m) throw new Error("no #__result sink in dumped DOM for " + name);
-    return JSON.parse(m[1].replace(/&quot;/g, '"').replace(/&amp;/g, "&")
-      .replace(/&lt;/g, "<").replace(/&gt;/g, ">"));
+    return JSON.parse(unescapeHtml(m[1]));
   } finally { if (!KEEP) rmSync(dir, { recursive: true, force: true }); }
 }
 

--- a/scripts/tests/core/test-extra-settings-dom.mjs
+++ b/scripts/tests/core/test-extra-settings-dom.mjs
@@ -35,6 +35,7 @@ import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { unescapeHtml } from "../lib/unescape-html.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const PAGE_JS = readFileSync(join(ROOT, "js/extra_settings_page.js"), "utf8");
@@ -1376,7 +1377,7 @@ for (const [name, fixture] of scenarios) {
     fail++;
     continue;
   }
-  const lines = m[1].split("\n").filter(Boolean).map((l) => l.replace(/&quot;/g, '"').replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">"));
+  const lines = m[1].split("\n").filter(Boolean).map(unescapeHtml);
   let n = 0;
   for (const line of lines) {
     if (line.startsWith("PASS")) { pass++; n++; continue; }

--- a/scripts/tests/lib/theme-engine-harness.mjs
+++ b/scripts/tests/lib/theme-engine-harness.mjs
@@ -23,6 +23,7 @@ import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
+import { unescapeHtml } from "./unescape-html.mjs";
 
 export const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 export const SKIP_EXIT = 3;
@@ -148,10 +149,7 @@ export function dumpDom(chromium, pagePath, extraArgs = []) {
 export function readProbe(dom, id) {
   const m = new RegExp('<pre id="' + id + '"[^>]*>([\\s\\S]*?)</pre>').exec(dom);
   if (!m) return null;
-  return m[1]
-    .replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">").replace(/&amp;/g, "&")
-    .trim().split("\n");
+  return unescapeHtml(m[1]).trim().split("\n");
 }
 
 /** Console reporter shared by all three suites. */

--- a/scripts/tests/lib/unescape-html.mjs
+++ b/scripts/tests/lib/unescape-html.mjs
@@ -1,0 +1,9 @@
+// Decoding &amp; before the others turns a literal "&lt;" into "<".
+export function unescapeHtml(s) {
+  return String(s)
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}


### PR DESCRIPTION
CodeQL flagged both of these on my fork.

**`js/incomplete-url-substring-sanitization`.** The dom-ready page-injection gates in `js/diff_views_main.js` and `js/panel_tabs_main.js` matched `claude.ai`/`claude.com` anywhere in the URL string, so `https://evil.example/?x=claude.ai` passed them. The injected page script is inert on a foreign page, but the gate now says what it means. diff_views reuses its own `originAllowed()` allowlist. panel_tabs compares the parsed hostname, kept looser than `ALLOWED_ORIGINS` so any claude.ai/claude.com subdomain keeps the injection.

**`js/double-escaping`.** Four test harnesses each carried their own inline entity-decode chain, and three decoded `&amp;` before `&lt;`/`&gt;`, so a result line containing a literal `&lt;` came out as `<`. A shared `scripts/tests/lib/unescape-html.mjs` now owns the chain, ampersand last, and every harness imports it.

Verified locally with `node --check` on every touched file and the seven DOM/theme harnesses (377, 110, 850, 30, 43, 127 and 15 assertions, all passing).

---

Two more PRs are on their way: shipping all icon sizes, and a byte-reproducible tarball build. One question: would you also take a CI parallelization PR? The amd64 and arm64 tarball builds run in parallel behind a shared bridge-build job, and `asar` comes from the Arch repos instead of a yay/AUR clone and makepkg in the container. Took my release runs from 23m to 18m.