### PR TITLE
Ship every icon size the official .deb carries

### DIFF
--- a/PKGBUILD.template
+++ b/PKGBUILD.template
@@ -125,10 +125,13 @@ Name=New Claude Code session
 Exec=claude-desktop claude://code/new
 EOF
 
-    # Install icon (included in tarball)
-    if [ -f "$srcdir/icons/claude-desktop.png" ]; then
-        install -Dm644 "$srcdir/icons/claude-desktop.png" \
-            "$pkgdir/usr/share/icons/hicolor/256x256/apps/claude-desktop.png"
+    # Install every icon size the tarball carries (mirrors the official .deb's
+    # usr/share/icons/hicolor/ tree).
+    if [ -d "$srcdir/icons/hicolor" ]; then
+        while IFS= read -r icon; do
+            install -Dm644 "$icon" \
+                "$pkgdir/usr/share/icons/hicolor/${icon#"$srcdir"/icons/hicolor/}"
+        done < <(find "$srcdir/icons/hicolor" -type f -name 'claude-desktop.png' | sort)
     fi
 
     # Upstream license notice (the official .deb's usr/share/doc copyright file,

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -201,10 +201,11 @@ cp "$APPDIR/com.anthropic.Claude.desktop" "$APPDIR/usr/share/applications/"
 
 # Copy icon
 log_info "Installing icon..."
-if [ -f "$WORK_DIR/tarball/icons/claude-desktop.png" ]; then
-    cp "$WORK_DIR/tarball/icons/claude-desktop.png" "$APPDIR/claude-desktop.png"
-    mkdir -p "$APPDIR/usr/share/icons/hicolor/256x256/apps"
-    cp "$WORK_DIR/tarball/icons/claude-desktop.png" "$APPDIR/usr/share/icons/hicolor/256x256/apps/"
+if [ -d "$WORK_DIR/tarball/icons/hicolor" ]; then
+    mkdir -p "$APPDIR/usr/share/icons"
+    cp -a "$WORK_DIR/tarball/icons/hicolor" "$APPDIR/usr/share/icons/"
+    # AppImage looks for the app icon at the AppDir root as well.
+    cp "$WORK_DIR/tarball/icons/hicolor/256x256/apps/claude-desktop.png" "$APPDIR/claude-desktop.png"
 else
     log_warn "Icon not found in tarball"
 fi

--- a/packaging/debian/build-deb.sh
+++ b/packaging/debian/build-deb.sh
@@ -101,7 +101,7 @@ mkdir -p "$DEB_ROOT/DEBIAN"
 mkdir -p "$DEB_ROOT/usr/lib/claude-desktop"
 mkdir -p "$DEB_ROOT/usr/bin"
 mkdir -p "$DEB_ROOT/usr/share/applications"
-mkdir -p "$DEB_ROOT/usr/share/icons/hicolor/256x256/apps"
+mkdir -p "$DEB_ROOT/usr/share/icons"
 
 # Install the official Claude Desktop tree VERBATIM (from the tarball's
 # claude-desktop/ dir): the Electron runtime, resources/app.asar (our patched
@@ -156,10 +156,9 @@ Name=New Claude Code session
 Exec=claude-desktop claude://code/new
 EOF
 
-# Install icon
-if [ -f "$WORK_DIR/tarball/icons/claude-desktop.png" ]; then
-    cp "$WORK_DIR/tarball/icons/claude-desktop.png" \
-        "$DEB_ROOT/usr/share/icons/hicolor/256x256/apps/claude-desktop.png"
+# Install every icon size the tarball carries
+if [ -d "$WORK_DIR/tarball/icons/hicolor" ]; then
+    cp -a "$WORK_DIR/tarball/icons/hicolor" "$DEB_ROOT/usr/share/icons/"
 fi
 
 # Debian policy: ship a copyright file under usr/share/doc/<pkg>/. The tarball

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -23,9 +23,9 @@ override_dh_auto_install:
 	install -d debian/claude-desktop/usr/share/applications
 	install -m644 debian/com.anthropic.Claude.desktop debian/claude-desktop/usr/share/applications/
 
-	# Install icon
-	install -d debian/claude-desktop/usr/share/icons/hicolor/256x256/apps
-	install -m644 icons/claude-desktop.png debian/claude-desktop/usr/share/icons/hicolor/256x256/apps/
+	# Install every icon size the tarball carries
+	install -d debian/claude-desktop/usr/share/icons
+	cp -a icons/hicolor debian/claude-desktop/usr/share/icons/
 
 override_dh_strip:
 	# Don't strip - Electron binaries don't like it

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -226,10 +226,10 @@ stdenvNoCC.mkDerivation {
         in "--prefix PATH : ${path}"
       ) extraSessionPaths}
 
-    # Install icon
-    if [ -f icons/claude-desktop.png ]; then
-      mkdir -p $out/share/icons/hicolor/256x256/apps
-      cp icons/claude-desktop.png $out/share/icons/hicolor/256x256/apps/claude-desktop.png
+    # Install every icon size the tarball carries
+    if [ -d icons/hicolor ]; then
+      mkdir -p $out/share/icons
+      cp -a icons/hicolor $out/share/icons/
     fi
 
     # Upstream license notice (tarball root, from the official .deb's

--- a/packaging/rpm/claude-desktop-extra.spec
+++ b/packaging/rpm/claude-desktop-extra.spec
@@ -173,11 +173,10 @@ Name=New Claude Code session
 Exec=claude-desktop claude://code/new
 DESKTOP
 
-# Install icon
-mkdir -p %{buildroot}/usr/share/icons/hicolor/256x256/apps
-if [ -f tarball/icons/claude-desktop.png ]; then
-    cp tarball/icons/claude-desktop.png \
-        %{buildroot}/usr/share/icons/hicolor/256x256/apps/claude-desktop.png
+# Install every icon size the tarball carries
+mkdir -p %{buildroot}/usr/share/icons
+if [ -d tarball/icons/hicolor ]; then
+    cp -a tarball/icons/hicolor %{buildroot}/usr/share/icons/
 fi
 
 %post
@@ -248,4 +247,4 @@ fi
 /usr/lib/claude-desktop/
 /usr/bin/claude-desktop
 /usr/share/applications/com.anthropic.Claude.desktop
-/usr/share/icons/hicolor/256x256/apps/claude-desktop.png
+/usr/share/icons/hicolor/*/apps/claude-desktop.png

--- a/scripts/build-patched-tarball.sh
+++ b/scripts/build-patched-tarball.sh
@@ -519,15 +519,27 @@ else
     log_warn "desktop-file-validate not installed — skipping .desktop validation"
 fi
 
-# Icon: the .deb ships pre-rendered PNGs under usr/share/icons/hicolor/. Use the
-# 256x256 one directly (no ImageMagick resize needed).
-ICON_SRC="$DATA_DIR/usr/share/icons/hicolor/256x256/apps/claude-desktop.png"
-ICON_DST="$TARBALL_DIR/icons/claude-desktop.png"
-if [ -f "$ICON_SRC" ]; then
-    cp "$ICON_SRC" "$ICON_DST"
+# Icons: the .deb ships pre-rendered PNGs at every size under
+# usr/share/icons/hicolor/. Mirror that tree into icons/hicolor/ so each
+# packager installs all of them; a panel asking for 16x16 gets the file made
+# for it instead of a downscaled 256x256.
+HICOLOR_SRC="$DATA_DIR/usr/share/icons/hicolor"
+ICON_DST="$TARBALL_DIR/icons/hicolor/256x256/apps/claude-desktop.png"
+ICON_COUNT=0
+if [ -d "$HICOLOR_SRC" ]; then
+    while IFS= read -r icon_src; do
+        icon_dst="$TARBALL_DIR/icons/hicolor/${icon_src#"$HICOLOR_SRC"/}"
+        mkdir -p "$(dirname "$icon_dst")"
+        cp "$icon_src" "$icon_dst"
+        ICON_COUNT=$((ICON_COUNT + 1))
+    done < <(find "$HICOLOR_SRC" -type f -name 'claude-desktop.png' | sort)
+fi
+if [ "$ICON_COUNT" -gt 0 ]; then
+    log_info "Bundled $ICON_COUNT icon size(s) from the .deb"
 else
     # Fallback: resources/icon.png (large), resized if ImageMagick is present.
     ICON_FALLBACK="$RES_DIR/icon.png"
+    mkdir -p "$(dirname "$ICON_DST")"
     if [ -f "$ICON_FALLBACK" ] && command -v magick &>/dev/null; then
         magick "$ICON_FALLBACK" -resize 256x256 "$ICON_DST"
     elif [ -f "$ICON_FALLBACK" ] && command -v convert &>/dev/null; then


### PR DESCRIPTION
The official .deb ships `claude-desktop.png` at 16, 32, 48, 128 and 256 under `usr/share/icons/hicolor/`, but `build-patched-tarball.sh` copied only the 256 into the tarball. Every package format therefore installed one icon, and panels, window lists and notifications downscaled it instead of using the file made for that size.

The tarball now mirrors the .deb's hicolor tree under `icons/hicolor/`, and every consumer installs all of it: the PKGBUILD, the deb and rpm packagers, the AppImage (which also keeps its AppDir-root copy), Nix, and the reference mapping in `packaging/debian/rules`.

Verified locally against the 1.26832.0 .deb: the build logs `Bundled 5 icon size(s) from the .deb`, all 45 patches apply, and the tarball lists `icons/hicolor/{16x16,32x32,48x48,128x128,256x256}/apps/claude-desktop.png`.