### PR TITLE
Make the tarball byte-reproducible

### DIFF
--- a/scripts/build-patched-tarball.sh
+++ b/scripts/build-patched-tarball.sh
@@ -575,8 +575,50 @@ case "$DEB_ARCH" in
     *)      TARBALL_FILE="$OUTPUT_DIR/claude-desktop-${VERSION}-linux-${DEB_ARCH}.tar.gz" ;;
 esac
 log_info "Creating tarball: $TARBALL_FILE"
-GZIP_PROG=$(command -v pigz || echo gzip)
-( cd "$TARBALL_DIR" && tar -I "$GZIP_PROG" -cf "$TARBALL_FILE" claude-desktop/ icons/ launcher/ copyright )
+
+# SOURCE_DATE_EPOCH pins every mtime tar records. When unset, derive it from the
+# newest file mtime in the upstream tree — Anthropic stamps those into the .deb,
+# so it is constant for a given input .deb. Restricted to -type f: tar leaves the
+# mtime of the directory it extracts INTO at creation time, so counting
+# directories reads back the build clock. The `|| true` keeps a failed pipeline
+# from aborting the assignment under `set -e`, so the fallback stays reachable.
+if [ -z "${SOURCE_DATE_EPOCH:-}" ]; then
+    SOURCE_DATE_EPOCH="$(find "$DATA_DIR" -type f -printf '%T@\n' 2>/dev/null | cut -d. -f1 | sort -n | tail -1 || true)"
+    [[ "$SOURCE_DATE_EPOCH" =~ ^[0-9]+$ ]] || SOURCE_DATE_EPOCH=0
+fi
+export SOURCE_DATE_EPOCH
+log_info "SOURCE_DATE_EPOCH: $SOURCE_DATE_EPOCH"
+
+# pigz and gzip emit different byte streams for identical input, so the
+# compressor is pinned. CLAUDE_ALLOW_PIGZ=1 trades byte-identical output for
+# speed on local builds.
+if [ "${CLAUDE_ALLOW_PIGZ:-0}" = "1" ] && command -v pigz &>/dev/null; then
+    GZIP_PROG="pigz"
+    log_warn "Using pigz (CLAUDE_ALLOW_PIGZ=1) — output is NOT byte-reproducible"
+else
+    GZIP_PROG="gzip"
+fi
+
+# --sort=name fixes entry order, which otherwise follows readdir and varies by
+# filesystem. --mtime and the ownership flags strip the build environment.
+# gzip -n omits the source filename and timestamp from the gzip header.
+TAR_FILE="${TARBALL_FILE%.gz}"
+( cd "$TARBALL_DIR" && tar \
+    --sort=name \
+    --format=gnu \
+    --owner=0 --group=0 --numeric-owner \
+    --mtime="@$SOURCE_DATE_EPOCH" \
+    -cf "$TAR_FILE" claude-desktop/ icons/ launcher/ copyright )
+
+# Hash the uncompressed layer too: when this matches across two builds but the
+# .gz does not, the divergence is in the compressor rather than the tree.
+TAR_SHA256="$(sha256sum "$TAR_FILE" | cut -d' ' -f1)"
+
+# Compress to a temporary name and rename on success, so a failure never leaves
+# a truncated archive at the path every packager reads by glob.
+"$GZIP_PROG" -n -9 -c "$TAR_FILE" > "$TARBALL_FILE.partial"
+mv "$TARBALL_FILE.partial" "$TARBALL_FILE"
+rm -f "$TAR_FILE"
 
 # Calculate SHA256
 SHA256=$(sha256sum "$TARBALL_FILE" | cut -d' ' -f1)
@@ -592,12 +634,16 @@ echo "  Arch:     $DEB_ARCH"
 echo "  Electron: ${ELECTRON_VERSION:-unknown}"
 echo "  Tarball:  $TARBALL_FILE"
 echo "  SHA256:   $SHA256"
+echo "  TAR SHA:  $TAR_SHA256"
+echo "  EPOCH:    $SOURCE_DATE_EPOCH"
 
 # Write metadata file for CI / orchestrators
 cat > "$OUTPUT_DIR/build-info.txt" << EOF
 VERSION="$VERSION"
 TARBALL="$TARBALL_FILE"
 SHA256="$SHA256"
+TAR_SHA256="$TAR_SHA256"
+SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH"
 ARCH="$DEB_ARCH"
 DEB_VERSION="$VERSION"
 ELECTRON_VERSION="${ELECTRON_VERSION:-unknown}"


### PR DESCRIPTION
The packaging step leaked build-environment state into the artifact, so two builds of identical content produced different hashes and a published tarball could not be checked against a local rebuild. Four sources, all in the final packaging step:

- **Compressor lottery.** `command -v pigz || echo gzip` picked whichever the build host had, and the two emit different byte streams for identical input. The compressor is pinned to gzip; `CLAUDE_ALLOW_PIGZ=1` opts back in for local speed at the cost of byte-identical output.
- **gzip header.** `gzip -n` drops the source filename and timestamp from the header. Compression also goes to a `.partial` that is renamed on success, so a failure never leaves a truncated archive at the path the packagers glob for.
- **Entry order.** `tar --sort=name`; the order otherwise follows readdir and varies by filesystem.
- **mtimes and ownership.** `tar --mtime` plus `--owner=0 --group=0 --numeric-owner`. `SOURCE_DATE_EPOCH` defaults to the newest file mtime in the extracted .deb tree, which Anthropic stamps, so it is constant for a given input .deb. Directory mtimes are excluded from that derivation: tar leaves the directory it extracts into at creation time, which reads back the build clock (measured: `usr/bin` carries the extraction time, every file carries the .deb's stamp).

`build-info.txt` gains `TAR_SHA256` and `SOURCE_DATE_EPOCH`; a matching `TAR_SHA256` alongside a differing `SHA256` isolates a divergence to the compressor.

Verified locally against the 1.26832.0 .deb: two consecutive builds produce byte-identical tarballs (`8598c523e22d882b459f2ec464834d1a010f7f295a72cee7f8ae7ba3929681bb`, `SOURCE_DATE_EPOCH=1785996342` from the .deb's own mtimes).

One question: my fork also runs a CI probe that builds the tarball twice in parallel jobs, fails on a hash mismatch, and publishes a GitHub build attestation for the artifact. Want that as a follow-up PR?