### PR TITLE
Run the two tarball builds in parallel; bump actions; asar from the repos

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -43,8 +43,9 @@ concurrency:
 # ──────────────────────────────────────────────────────────────────────
 # Job graph (fan-out / fan-in):
 #
-#   check-version ──► build-tarball         (amd64: ingest official .deb)
-#         │           build-aarch64-tarball (arm64: ingest official arm64 .deb)
+#   check-version ──► build-bridges (Computer Use bridges, both arches, cached)
+#         │                  ├── build-tarball         (amd64: ingest official .deb)
+#         │                  └── build-aarch64-tarball (arm64: ingest official arm64 .deb)
 #         │                  │
 #         │                  ├── package-appimage (matrix: x86_64, aarch64)
 #         │                  ├── package-deb      (matrix: amd64, arm64)
@@ -414,22 +415,18 @@ jobs:
   # ================================================================
   # Job 2: Build the patched tarball (the main bottleneck)
   # ================================================================
-  build-tarball:
+  # ================================================================
+  # Job 2a: Build the Computer Use bridges (both architectures)
+  #
+  # Separate from build-tarball so the amd64 and aarch64 tarball builds can
+  # run in parallel: both only need these binaries (cached on upstream HEAD,
+  # so this job is seconds on a cache hit) and their own .deb artifact.
+  # ================================================================
+  build-bridges:
     needs: check-version
     if: needs.check-version.outputs.should_build == 'true'
     runs-on: ubuntu-latest
-    outputs:
-      tarball_sha256: ${{ steps.build.outputs.tarball_sha256 }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Download amd64 .deb artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: claude-deb-amd64
-          path: deb-input
-
       - name: Get kwin-portal-bridge repo HEAD
         id: bridge-rev
         run: |
@@ -857,6 +854,67 @@ jobs:
             echo "::warning::aarch64-linux-gnu-objdump unavailable — could not enforce glibc floor on the arm64 bridge"
           fi
 
+      - name: Upload x86_64 bridge binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: bridges-x86_64
+          path: |
+            /tmp/bridge-output/kwin-portal-bridge
+            /tmp/x11-bridge-output/x11-bridge
+            /tmp/wlroots-bridge-output/wlroots-bridge
+            /tmp/gnome-bridge-output/gnome-portal-bridge
+          retention-days: 1
+
+      - name: Upload kwin-portal-bridge aarch64 binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: kwin-portal-bridge-aarch64
+          path: /tmp/bridge-output/kwin-portal-bridge-aarch64
+          retention-days: 1
+
+      - name: Upload x11-bridge aarch64 binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: x11-bridge-aarch64
+          path: /tmp/x11-bridge-output/x11-bridge-aarch64
+          retention-days: 1
+
+      - name: Upload wlroots-bridge aarch64 binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: wlroots-bridge-aarch64
+          path: /tmp/wlroots-bridge-output/wlroots-bridge-aarch64
+          retention-days: 1
+
+      - name: Upload gnome-portal-bridge aarch64 binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: gnome-portal-bridge-aarch64
+          path: /tmp/gnome-bridge-output/gnome-portal-bridge-aarch64
+          retention-days: 1
+
+  build-tarball:
+    needs: [check-version, build-bridges]
+    if: needs.check-version.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      tarball_sha256: ${{ steps.build.outputs.tarball_sha256 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Download amd64 .deb artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: claude-deb-amd64
+          path: deb-input
+
+      - name: Download x86_64 bridge binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: bridges-x86_64
+          path: /tmp
+
       - name: Build Patched Tarball (ingest official amd64 .deb)
         id: build
         run: |
@@ -902,20 +960,10 @@ jobs:
 
               echo '=== Installing build dependencies ==='
               pacman -Syu --noconfirm
-              pacman -S --noconfirm python nodejs npm git imagemagick shellcheck nim nimble binutils tar zstd xz gnupg
+              pacman -S --noconfirm python nodejs npm git imagemagick shellcheck nim nimble binutils tar zstd xz gnupg asar
 
               echo '=== Installing Nim regex package ==='
               nimble install -y regex
-
-              echo '=== Installing asar from AUR ==='
-              useradd -m builder
-              echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-              cd /tmp
-              git clone https://aur.archlinux.org/yay-bin.git
-              chown -R builder:builder yay-bin
-              cd yay-bin
-              su builder -c 'makepkg -si --noconfirm'
-              su builder -c 'yay -S --noconfirm asar'
 
               echo '=== Running ingest+patch script (build-patched-tarball.sh) ==='
               # Local .deb already SHA-verified in check-version; GPG verify of a
@@ -963,34 +1011,6 @@ jobs:
           path: /tmp/build-output/claude-desktop-*-linux.tar.gz
           retention-days: 1
 
-      - name: Upload kwin-portal-bridge aarch64 binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: kwin-portal-bridge-aarch64
-          path: /tmp/bridge-output/kwin-portal-bridge-aarch64
-          retention-days: 1
-
-      - name: Upload x11-bridge aarch64 binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: x11-bridge-aarch64
-          path: /tmp/x11-bridge-output/x11-bridge-aarch64
-          retention-days: 1
-
-      - name: Upload wlroots-bridge aarch64 binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: wlroots-bridge-aarch64
-          path: /tmp/wlroots-bridge-output/wlroots-bridge-aarch64
-          retention-days: 1
-
-      - name: Upload gnome-portal-bridge aarch64 binary
-        uses: actions/upload-artifact@v7
-        with:
-          name: gnome-portal-bridge-aarch64
-          path: /tmp/gnome-bridge-output/gnome-portal-bridge-aarch64
-          retention-days: 1
-
       - name: Upload Build Log
         if: always()
         uses: actions/upload-artifact@v7
@@ -1010,7 +1030,7 @@ jobs:
   # arch-agnostic JS, so this runs in an amd64 Arch container — no QEMU.
   # ================================================================
   build-aarch64-tarball:
-    needs: [check-version, build-tarball]
+    needs: [check-version, build-bridges]
     if: needs.check-version.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     outputs:
@@ -1084,16 +1104,8 @@ jobs:
             bash -c "
               set -eo pipefail
               pacman -Syu --noconfirm
-              pacman -S --noconfirm python nodejs npm git imagemagick shellcheck nim nimble binutils tar zstd xz gnupg
+              pacman -S --noconfirm python nodejs npm git imagemagick shellcheck nim nimble binutils tar zstd xz gnupg asar
               nimble install -y regex
-              useradd -m builder
-              echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-              cd /tmp
-              git clone https://aur.archlinux.org/yay-bin.git
-              chown -R builder:builder yay-bin
-              cd yay-bin
-              su builder -c 'makepkg -si --noconfirm'
-              su builder -c 'yay -S --noconfirm asar'
               # arm64 .deb already SHA-verified in check-version; skip smoke test
               # (arm64 Electron can't run in this amd64 container) + GPG (local file).
               ${BRIDGE_ENV} CLAUDE_GPG_VERIFY=0 SKIP_SMOKE_TEST=1 \

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -94,7 +94,7 @@ jobs:
       should_build: ${{ steps.decide.outputs.should_build }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Full history for git changelog generation
 
@@ -290,7 +290,7 @@ jobs:
 
       - name: Upload amd64 .deb for build job
         if: steps.decide.outputs.should_build == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: claude-deb-amd64
           path: |
@@ -300,7 +300,7 @@ jobs:
 
       - name: Upload arm64 .deb for build job
         if: steps.decide.outputs.should_build == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: claude-deb-arm64
           path: |
@@ -317,7 +317,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run shellcheck on all scripts
         run: |
@@ -422,10 +422,10 @@ jobs:
       tarball_sha256: ${{ steps.build.outputs.tarball_sha256 }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download amd64 .deb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: claude-deb-amd64
           path: deb-input
@@ -439,7 +439,7 @@ jobs:
 
       - name: Cache kwin-portal-bridge binaries
         id: bridge-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/bridge-output
           key: kwin-portal-bridge-${{ steps.bridge-rev.outputs.sha }}
@@ -573,7 +573,7 @@ jobs:
 
       - name: Cache x11-bridge binaries
         id: x11-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/x11-bridge-output
           key: x11-bridge-${{ steps.x11-rev.outputs.sha }}
@@ -658,7 +658,7 @@ jobs:
 
       - name: Cache wlroots-bridge binaries
         id: wlroots-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/wlroots-bridge-output
           key: wlroots-bridge-${{ steps.wlroots-rev.outputs.sha }}
@@ -738,7 +738,7 @@ jobs:
 
       - name: Cache gnome-portal-bridge binaries
         id: gnome-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /tmp/gnome-bridge-output
           key: gnome-portal-bridge-${{ steps.gnome-rev.outputs.sha }}
@@ -957,35 +957,35 @@ jobs:
           echo "  SHA256:   ${SHA256}"
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tarball
           path: /tmp/build-output/claude-desktop-*-linux.tar.gz
           retention-days: 1
 
       - name: Upload kwin-portal-bridge aarch64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: kwin-portal-bridge-aarch64
           path: /tmp/bridge-output/kwin-portal-bridge-aarch64
           retention-days: 1
 
       - name: Upload x11-bridge aarch64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: x11-bridge-aarch64
           path: /tmp/x11-bridge-output/x11-bridge-aarch64
           retention-days: 1
 
       - name: Upload wlroots-bridge aarch64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlroots-bridge-aarch64
           path: /tmp/wlroots-bridge-output/wlroots-bridge-aarch64
           retention-days: 1
 
       - name: Upload gnome-portal-bridge aarch64 binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gnome-portal-bridge-aarch64
           path: /tmp/gnome-bridge-output/gnome-portal-bridge-aarch64
@@ -993,7 +993,7 @@ jobs:
 
       - name: Upload Build Log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-log
           path: build-output.log
@@ -1017,31 +1017,31 @@ jobs:
       tarball_aarch64_sha256: ${{ steps.build.outputs.tarball_aarch64_sha256 }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download arm64 .deb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: claude-deb-arm64
           path: deb-input
 
       - name: Download kwin-portal-bridge aarch64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: kwin-portal-bridge-aarch64
 
       - name: Download x11-bridge aarch64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: x11-bridge-aarch64
 
       - name: Download wlroots-bridge aarch64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wlroots-bridge-aarch64
 
       - name: Download gnome-portal-bridge aarch64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gnome-portal-bridge-aarch64
 
@@ -1116,7 +1116,7 @@ jobs:
           echo "Built aarch64 tarball: $(basename "$TARBALL") (arch=${ARCH:-arm64}, SHA256: ${SHA256})"
 
       - name: Upload aarch64 tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tarball-aarch64
           path: claude-desktop-*-linux-aarch64.tar.gz
@@ -1134,19 +1134,19 @@ jobs:
         arch: [x86_64, aarch64]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # amd64 -> `tarball`; aarch64 -> `tarball-aarch64` (already built from the
       # official arm64 .deb, with arm64 Electron + kwin-portal-bridge baked in).
       - name: Download x86_64 tarball
         if: matrix.arch == 'x86_64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarball
 
       - name: Download aarch64 tarball
         if: matrix.arch == 'aarch64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarball-aarch64
 
@@ -1213,7 +1213,7 @@ jobs:
           fi
 
       - name: Upload AppImage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: appimage-${{ matrix.arch }}
           path: |
@@ -1233,19 +1233,19 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # amd64 -> `tarball`; arm64 -> `tarball-aarch64` (official arm64 .deb,
       # arm64 Electron + kwin-portal-bridge already bundled).
       - name: Download amd64 tarball
         if: matrix.arch == 'amd64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarball
 
       - name: Download arm64 tarball
         if: matrix.arch == 'arm64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarball-aarch64
 
@@ -1256,7 +1256,7 @@ jobs:
       # below (not to build it — the tarball already carries arm64 binaries).
       - name: Set up QEMU for ARM64
         if: matrix.arch == 'arm64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
@@ -1348,7 +1348,7 @@ jobs:
           fi
 
       - name: Upload Debian package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deb-${{ matrix.arch }}
           path: dist/claude-desktop-extra_*_${{ matrix.arch }}.deb
@@ -1360,7 +1360,7 @@ jobs:
       # Retire this step with the rename transition window.
       - name: Upload transitional deb artifact (amd64 build only)
         if: matrix.arch == 'amd64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deb-transitional
           path: dist/claude-desktop-bin_*_all.deb
@@ -1379,19 +1379,19 @@ jobs:
         arch: [x86_64, aarch64]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # x86_64 -> `tarball`; aarch64 -> `tarball-aarch64` (official arm64 .deb,
       # arm64 Electron + kwin-portal-bridge already bundled).
       - name: Download x86_64 tarball
         if: matrix.arch == 'x86_64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarball
 
       - name: Download aarch64 tarball
         if: matrix.arch == 'aarch64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarball-aarch64
 
@@ -1399,7 +1399,7 @@ jobs:
       # step below (not to build it — the tarball already carries arm64 binaries).
       - name: Set up QEMU for ARM64
         if: matrix.arch == 'aarch64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
 
@@ -1472,7 +1472,7 @@ jobs:
           fi
 
       - name: Upload RPM package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rpm-${{ matrix.arch }}
           path: dist/claude-desktop-extra-*.${{ matrix.arch }}.rpm
@@ -1489,15 +1489,15 @@ jobs:
       nix_hash: ${{ steps.nix-build.outputs.nix_hash }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarball
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31
 
       - name: Build with Nix
         id: nix-build
@@ -1529,7 +1529,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate PKGBUILD
         env:
@@ -1598,7 +1598,7 @@ jobs:
           cat .SRCINFO
 
       - name: Upload PKGBUILD artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pkgbuild
           # The .install file is referenced by PKGBUILD's `install=` field and
@@ -1641,24 +1641,24 @@ jobs:
         arch: [x86_64, aarch64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # x86_64 -> `tarball`; aarch64 -> `tarball-aarch64` (official arm64 .deb,
       # arm64 Electron + kwin-portal-bridge already bundled).
       - name: Download x86_64 tarball
         if: matrix.arch == 'x86_64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarball
 
       - name: Download aarch64 tarball
         if: matrix.arch == 'aarch64'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarball-aarch64
 
       - name: Download PKGBUILD
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pkgbuild
 
@@ -1856,7 +1856,7 @@ jobs:
             '
 
       - name: Upload Arch package (${{ matrix.arch }})
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: arch-package-${{ matrix.arch }}
           path: dist/claude-desktop-extra-*-${{ matrix.arch }}.pkg.tar.zst
@@ -1881,7 +1881,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -1928,7 +1928,7 @@ jobs:
           exit 1
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -2153,7 +2153,7 @@ jobs:
           RPM_X86_SHA: ${{ steps.files.outputs.rpm_x86_64_sha256 }}
           RPM_ARM_SHA: ${{ steps.files.outputs.rpm_aarch64_sha256 }}
           REPO: ${{ github.repository }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.check-version.outputs.tag }}
           name: ${{ needs.check-version.outputs.release_name }}
@@ -2421,7 +2421,7 @@ jobs:
           tar -czf /tmp/gh-pages-content.tar.gz -C "$REPO_DIR" .
 
       - name: Upload gh-pages content
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gh-pages-content
           path: /tmp/gh-pages-content.tar.gz
@@ -2631,20 +2631,20 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install RPM tooling
         run: dnf install -y rpm-sign createrepo_c gnupg2
 
       - name: Download RPM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: rpm-*
           path: rpm-files/
           merge-multiple: true
 
       - name: Download gh-pages content from release job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: gh-pages-content
           path: /tmp/
@@ -2683,7 +2683,7 @@ jobs:
           done
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: /tmp/gh-pages-repo
 
@@ -2703,7 +2703,7 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   # ================================================================
   # Job 6b: LEGACY MIRROR (retire with the rename transition window)
@@ -2741,12 +2741,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (latest master with updated hash)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: master
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@v31
 
       - name: Build with real fetchurl from GitHub Releases
         run: |
@@ -2773,7 +2773,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -14,7 +14,7 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # ----------------------------------------------------------------
       # Poll the official Linux .deb apt repository (NOT the old Windows


### PR DESCRIPTION
The follow-up from #219. Two commits:

**Bump every action to its current major.** checkout v4 to v7, download-artifact v4 to v8, upload-artifact v4 to v7, cache v4 to v6, deploy-pages v4 to v5, upload-pages-artifact v4 to v5, cachix/install-nix-action v27 to v31, docker/setup-qemu-action v3 to v4, softprops/action-gh-release v2 to v3; 61 references across build-and-release.yml and version-check.yml. My fork's whole release pipeline runs on these versions.

**Parallelize the tarball builds.** The aarch64 tarball build waited for the full amd64 build, but the only thing it consumed from it was the set of Computer Use bridge binaries. Those now build in their own `build-bridges` job (cached on the bridge repos' HEAD, so it is seconds on a warm cache), and both tarball builds fan out from it and run concurrently. The bridge build/verify steps moved verbatim; the amd64 tarball job downloads them as one `bridges-x86_64` artifact restored to the `/tmp` paths the build step already probes.

Both container scripts also install `asar` from the Arch repos instead of cloning yay-bin from the AUR and building it with makepkg. That drops an unpinned AUR fetch from the supply chain and several minutes from each container run.

Measured on my fork with the same restructure: a release run went from 23m12s to 18m11s, with `build-bridges` at 28s on a warm cache and both tarball jobs starting within one second of each other.

actionlint reports byte-for-byte the same findings before and after the restructure (nothing new introduced), and the job graph parses with `build-tarball` and `build-aarch64-tarball` both needing `[check-version, build-bridges]`.