### PR TITLE
Fix panel tabs after remote redeploy, diff-scope dropdown leak, and growthbook hook on 1.34493.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the claude-desktop-extra packages will be documented in this file.
 
+## 2026-08-21
+
+### Two community-feature fixes: panel tabs revived after a remote claude.ai redeploy, diff-scope dropdown no longer leaks into other panels
+
+Both breaks were in the remote claude.ai page (epitaxy), so they arrived without any desktop release. Diagnosed live over CDP against a running 1.32352.1 install.
+
+- **Panel tabs stopped rendering entirely.** A remote redeploy put an `aria-hidden="true"` `.epitaxy-view-panel` ghost node (no `[data-pane-root]`, no fiber `tileId`, no chrome) inside the chat column's `.tiles-shell`. The chat-column discriminator required every shell to be empty, so it failed each frame, warned `no-chat-column`, and the tab bar never armed. Fix: an aria-hidden view panel no longer counts as shell occupancy (`chatLooksRight` in `panel_tabs_page.js`, and the harvester's `.epitaxy-view-panel` fallback in `panel_tabs_harvest.js` skips ghosts too). A non-hidden view panel still disqualifies, so the decoy defense is unchanged. The DOM suite's chat fixture now ships the ghost, plus a new `ghost-decoy` scenario (380 assertions).
+- **The diff-scope dropdown (Working tree / Branch changes / Latest turn) mounted in the browser and Files panels.** With a non-working scope applied, an empty in-app browser tab ("New tab", no iframe mounted yet) passed every gate of the empty-diff fallback (`qualifiesAsEmptyDiffView`): non-working mode, real `.epitaxy-view-panel` wrapper, and nothing for the negative terminal/browser surface check to match. Fix: a positive identity gate - the React fiber's `memoizedProps.tileId` must be `"diff"` before the fallback fires; a resolvable non-diff id is a hard no, while a null id (unreadable fiber) falls back to the old gates so the emptied-diff rescue survives a React internals rename. The same gate runs in the re-validation sweep, so an already-leaked dropdown is removed on the next sweep. New `leak` DOM scenario pins install-refusal, the dead-end rescue, re-validation stripping, and the null-fiber fallback (117 assertions).
+
+`baseline/PANEL_TABS_ANCHORS.md` re-validated against the live page (A1 updated with the ghost exception). Patch count unchanged.
+
 ## 2026-08-19
 
 ### Claude Desktop v1.32885.1 - zero patch changes; release healed after a CI infrastructure timeout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the claude-desktop-extra packages will be documented in this file.
 
+## 2026-08-22
+
+### add_growthbook_overrides re-fitted for Claude Desktop v1.34493.1
+
+Upstream reshaped the features-store setter: it now takes a second (source/status) parameter, drops the dirty flag, and routes the stored value through the deployment-mode hardcoded-features filter, which used to be a separate load path calling the setter. Sub-patch B now wraps that transform call instead of reassigning the raw parameter, so overrides still apply to the map that is actually stored - the same layering as before (user override > any rollout). Anchor unchanged: the `[growthbook] loaded %d features (%d changed)` log line.
+
 ## 2026-08-21
 
 ### Two community-feature fixes: panel tabs revived after a remote claude.ai redeploy, diff-scope dropdown no longer leaks into other panels

--- a/baseline/PANEL_TABS_ANCHORS.md
+++ b/baseline/PANEL_TABS_ANCHORS.md
@@ -1,6 +1,12 @@
 # Panel tabs - upstream anchor inventory
 
 **Validated against Claude Desktop 1.24012.9** (2026-08-06).
+**Re-validated live over CDP on 1.32352.1** (2026-08-21) after a remote claude.ai redeploy
+broke A1: the chat column's absolute shell now contains an `aria-hidden="true"`
+`.epitaxy-view-panel` GHOST (no `[data-pane-root]`, no fiber `tileId`, no chrome row). The
+discriminator now ignores aria-hidden view panels when testing shell emptiness - see A1.
+The redeploy also introduced a `dframe-*` app shell around the epitaxy area and a new
+`runs` tile id in the side-pane store; neither affects any anchor below.
 
 Everything the panel-tabs feature reaches into remote claude.ai markup or its React
 fiber. Re-validate this list on every upstream bump: a green build proves the Nim
@@ -57,7 +63,7 @@ the *feature* stops working until the assumption is re-established.
 
 | # | Assumption | Where | Expected on 1.24012.9 | If it breaks |
 |---|---|---|---|---|
-| A1 | **The empty, ABSOLUTELY POSITIONED shell.** The chat column is the row child that owns ≥ 1 `.tiles-shell`, whose shells are **all empty** (no `[data-pane-root]` / `.epitaxy-view-panel` in any of them), of which **≥ 1 is `position: absolute`**, and which is not one of our tagged columns. Exactly one row child may qualify - two ⇒ refuse. The pick is then **held** (`stickyChat`) and re-decided only when the held element stops qualifying | `panel_tabs_page.js` - `chatLooksRight`, `stickyChatOk`, `chatColumnOf`, `looksLikeRow` | row children `chat, .tiles-handle, STACK(diff,terminal), .tiles-handle, STACK(preview,tasks)`; shells/shells-with-a-pane = chat **1/0**, handles **0/–**, each stack **2/2** (1 empty shell of 5 document-wide). **Position: chat's shell `absolute`** (inline `position:absolute;top/bottom/left:0;min-width:320px`), all four side shells `static` with a byte-identical inline style carrying no `position` | No single qualifying chat column ⇒ refuse to arm, warn `no-chat-column`, drop our bar, leave upstream's split. If a side shell ever becomes `absolute` (or chat's `static`) the discriminator weakens - stickiness bounds that to the first identification. Fix `chatLooksRight` |
+| A1 | **The "empty", ABSOLUTELY POSITIONED shell.** The chat column is the row child that owns ≥ 1 `.tiles-shell`, whose shells are **all empty** - no `[data-pane-root]`, and no `.epitaxy-view-panel` **that is not `aria-hidden="true"`** - of which **≥ 1 is `position: absolute`**, and which is not one of our tagged columns. Exactly one row child may qualify - two ⇒ refuse. The pick is then **held** (`stickyChat`) and re-decided only when the held element stops qualifying. **The aria-hidden exception is load-bearing since 2026-08-21:** a remote redeploy put an `aria-hidden="true"` `.epitaxy-view-panel` ghost inside the chat shell (no pane root, no fiber `tileId`, no chrome), which made the plain emptiness test fail every frame and killed the feature. A REAL pane never carries `aria-hidden="true"` (checked live: diff/preview do not) | `panel_tabs_page.js` - `chatLooksRight`, `stickyChatOk`, `chatColumnOf`, `looksLikeRow` | 1.24012.9: row children `chat, .tiles-handle, STACK(diff,terminal), .tiles-handle, STACK(preview,tasks)`; shells/shells-with-a-pane = chat **1/0**, handles **0/–**, each stack **2/2**. 1.32352.1 (live 2026-08-21): row children `chat(826px), .tiles-handle(12px), STACK(diff,preview)(957px)`; chat's shell `absolute` holding ONLY the ghost + the chat UI (composer measured inside it), side shells `static` with 1 pane each | No single qualifying chat column ⇒ refuse to arm, warn `no-chat-column`, drop our bar, leave upstream's split. If a side shell ever becomes `absolute` (or chat's `static`) the discriminator weakens - stickiness bounds that to the first identification. If upstream ever ships a REAL pane with `aria-hidden="true"`, or drops the ghost's `aria-hidden`, re-derive. Fix `chatLooksRight` |
 | A2 | **Nesting depth.** Leaf wrapper → row is at most `MAX_CHAIN_HOPS = 12` parent hops | `panel_tabs_page.js` - `resolveChain` | 2 hops for a tile inside a stack, 1 for a row-level tile | Row unresolvable ⇒ hide nothing, warn `no-row`. Raise the budget |
 | A3 | **The literal tile id `"chat"`.** Used to separate the chat pane from side panes | `panel_tabs_page.js` - `isNonChatPane`, `resolveColumns`; `panel_tabs_layout.js` - `sideTileIds`, `geometry` | `tid(chatPane) === "chat"` | The chat tile counts as a side panel ⇒ it gets a tab and can be hidden. Grep the literal and update |
 
@@ -73,7 +79,7 @@ that menu; nothing reads them now.
 
 | Anchor | Where | Expected on 1.24012.9 |
 |---|---|---|
-| `[data-pane-root]`, fallback `.epitaxy-view-panel` | `harvest.panes` | present on every pane |
+| `[data-pane-root]`, fallback `.epitaxy-view-panel` (fallback skips `aria-hidden="true"` ghosts since 2026-08-21) | `harvest.panes` | present on every pane; the chat shell's ghost carries NEITHER a pane root nor a resolvable `tileId` |
 | `memoizedProps.tileId` on an ancestor fiber, searched not hop-counted | `harvest.tileIdOf` | observed at hops 1 / 39 / 51 - never hardcode |
 | `.tiles-shell` (one per column; a bare query returns the CHAT column's, which is empty) | page `SHELL_SELECTOR` | one per column; see A1 for the position split |
 | `.tiles-handle` resize dividers, `role="separator"` | page `HANDLE_SELECTOR` | row: vertical 12 px; in-stack: horizontal 12 px |

--- a/js/diff_views_page.js
+++ b/js/diff_views_page.js
@@ -117,6 +117,33 @@
   // not. This exists so the fallback cannot reach a non-diff tile.
   var NON_DIFF_SURFACE_SELECTOR = 'canvas,iframe,webview,[class*="xterm"],[class*="terminal"]';
   var MAX_VIEW_WALK = 8; // only used when there is no view-panel ancestor
+
+  // ---- FIBER IDENTITY: which tile does a panel actually belong to? ----------
+  // React leaves its fiber on every rendered node under a __reactFiber$<hash>
+  // key, and an ANCESTOR fiber's memoizedProps carries the tile's identity as a
+  // plain string prop `tileId` ("diff", "preview", "terminal", "chat", ...).
+  // Measured live 2026-08-21 on 1.32352.1: from the .epitaxy-view-panel node the
+  // prop resolves within 3-5 hops; panel tabs' harvester has used the same walk
+  // (bounded, SEARCHED - never a hardcoded hop count) since 2026-08-04.
+  // Returns null when the fiber key or the prop cannot be found - callers must
+  // treat null as "unknown", never as "not a diff".
+  var DIFF_TILE_ID = "diff";
+  var MAX_FIBER_HOPS = 120;
+
+  function fiberTileIdOf(el) {
+    try {
+      var key = null;
+      for (var k in el) { if (k.indexOf("__reactFiber$") === 0) { key = k; break; } }
+      if (!key) return null;
+      var f = el[key], hops = 0;
+      while (f && hops++ < MAX_FIBER_HOPS) {
+        var p = f.memoizedProps;
+        if (p && typeof p.tileId === "string") return p.tileId;
+        f = f.return;
+      }
+    } catch (e) { /* a foreign fiber shape must never break qualification */ }
+    return null;
+  }
   var SWEEP_MS = 500;
   var NO_PANEL_SWEEP_THRESHOLD = 10;
   var PENDING_CUE_MS = 600;
@@ -202,8 +229,9 @@
   // That state is DOM-INDISTINGUISHABLE from a Terminal tile on the evidence we
   // have (no Terminal-tile DOM was ever captured, and no positive Terminal
   // marker is known to exist), so the fallback is gated on something outside the
-  // DOM instead - our own applied mode - plus a negative surface check. The
-  // three gates are documented individually below; between them, the fallback
+  // DOM instead - our own applied mode - plus, since 2026-08-21, the React
+  // fiber's own tile identity (GATE 3), plus a negative surface check. The
+  // four gates are documented individually below; between them, the fallback
   // cannot fire in the default Working tree scope at all, which is the only
   // scope a user who never touched our dropdown is ever in.
   function looksLikeNonDiffSurface(node) {
@@ -224,7 +252,21 @@
     // this path and "qualify" some shared ancestor.
     if (!node || !node.matches) return false;
     try { if (!node.matches(VIEW_CONTAINER_SELECTOR)) return false; } catch (e) { return false; }
-    // GATE 3 - and it must not be a terminal / embedded-browser surface.
+    // GATE 3 - POSITIVE IDENTITY (2026-08-21, the dropdown-leak fix). The
+    // paragraph above says the empty state is DOM-indistinguishable from other
+    // tiles - it no longer has to be: the React fiber's memoizedProps.tileId
+    // names the owning tile outright. Measured live on 1.32352.1: an EMPTY
+    // in-app browser tab ("New tab", no iframe mounted yet) sailed through
+    // gates 1 and 2 and the negative surface check below (nothing to match!),
+    // and our dropdown landed in its chrome row - tileId said "preview" the
+    // whole time. A resolvable tileId that is not "diff" is a hard no. A null
+    // (unreadable fiber - a React internals rename) falls through to the old
+    // gates, so the dead-end rescue cannot be lost to an upstream refactor;
+    // the leak can only return in that degraded state, and the "leak" DOM
+    // scenario pins both directions.
+    var tid = fiberTileIdOf(node);
+    if (tid !== null && tid !== DIFF_TILE_ID) return false;
+    // GATE 4 - and it must not be a terminal / embedded-browser surface.
     if (looksLikeNonDiffSurface(node)) return false;
     return true;
   }
@@ -428,7 +470,8 @@
       "] document[" + describeMarkers(document) +
       "] appliedMode=" + lastKnownMode +
       " emptyDiffFallback=" + (wrapper ? qualifiesAsEmptyDiffView(wrapper) : false) +
-      " nonDiffSurface=" + (wrapper ? looksLikeNonDiffSurface(wrapper) : "n/a"));
+      " nonDiffSurface=" + (wrapper ? looksLikeNonDiffSurface(wrapper) : "n/a") +
+      " tileId=" + (wrapper ? fiberTileIdOf(wrapper) : "n/a"));
   }
 
   var setModeFailLogged = false;

--- a/js/panel_tabs_harvest.js
+++ b/js/panel_tabs_harvest.js
@@ -48,8 +48,18 @@
   }
   function panes() {
     var list = document.querySelectorAll(PANE_SELECTOR);
-    if (!list.length) list = document.querySelectorAll(PANE_FALLBACK);
-    return Array.prototype.slice.call(list);
+    if (list.length) return Array.prototype.slice.call(list);
+    // Fallback path only: skip aria-hidden view panels. Upstream renders an
+    // aria-hidden="true" .epitaxy-view-panel GHOST inside the chat shell
+    // (measured 2026-08-21 on 1.32352.1) - it has no fiber tileId, so counting
+    // it here would report a pane that can never resolve and trip the
+    // anchor-rot warning the moment [data-pane-root] goes away.
+    var out = [], all = document.querySelectorAll(PANE_FALLBACK), i;
+    for (i = 0; i < all.length; i++) {
+      if (all[i].getAttribute && all[i].getAttribute("aria-hidden") === "true") continue;
+      out.push(all[i]);
+    }
+    return out;
   }
 
   function tileIdOf(el) {

--- a/js/panel_tabs_page.js
+++ b/js/panel_tabs_page.js
@@ -646,13 +646,23 @@
     // One of OUR side columns can never be the chat column, whatever its panes are
     // doing this frame.
     if (el.hasAttribute && el.hasAttribute(COL_ATTR)) return false;
-    var shells = el.querySelectorAll(SHELL_SELECTOR), i, abs = false;
+    var shells = el.querySelectorAll(SHELL_SELECTOR), i, j, abs = false;
     // It must own a shell...
     if (!shells.length) return false;
-    // ...every one of them must be empty, by either of upstream's two pane anchors...
+    // ...every one of them must be empty, by either of upstream's two pane anchors.
+    // "Empty" ignores aria-hidden view panels (2026-08-21, measured on 1.32352.1):
+    // a remote redeploy put an aria-hidden="true" .epitaxy-view-panel GHOST (no
+    // [data-pane-root], no fiber tileId, no chrome) inside the chat shell, which
+    // made this test fail every frame - no-chat-column warned and the bar never
+    // armed. A hidden-from-AT ghost is not occupancy; a REAL pane never carries
+    // aria-hidden="true" (live check: the diff/preview panels do not).
     for (i = 0; i < shells.length; i++) {
       if (shells[i].querySelector(PANE_SELECTOR)) return false;
-      if (shells[i].querySelector(PANE_FALLBACK_SELECTOR)) return false;
+      var vps = shells[i].querySelectorAll(PANE_FALLBACK_SELECTOR);
+      for (j = 0; j < vps.length; j++) {
+        if (vps[j].getAttribute && vps[j].getAttribute("aria-hidden") === "true") continue;
+        return false;
+      }
     }
     if (!window.getComputedStyle) return true;
     // ...and at least one must be out of flow, which no side wrapper's is.

--- a/patches/core/add_growthbook_overrides.nim
+++ b/patches/core/add_growthbook_overrides.nim
@@ -66,23 +66,33 @@ proc apply*(input: string): string =
   # separate `let` for the second binding, dotted logger callee):
   #   function tS(e){let t=Mx;Mx=e,Nx=!0;let n=Object.keys(Mx).length,
   #     i=Object.entries(Mx).filter(...).length;r.o.info(`[growthbook] loaded %d features (%d changed)`,n,i)
+  # v1.34493.1 shape: the setter takes a SECOND parameter (a source/status tag,
+  # stored first), the dirty flag is gone, and the stored value now funnels
+  # through a TRANSFORM - the deployment-mode hardcoded-features filter, which
+  # used to be a separate load path calling the setter:
+  #   function Fit(e,t){OS=t;let n=DS;DS=jit(e);let r=Object.keys(DS).length,
+  #     i=Object.entries(DS).filter(...).length;D.info(`[growthbook] loaded %d features (%d changed)`,r,i)
+  # We now wrap the TRANSFORM CALL (`jit(e)`) rather than reassigning the raw
+  # parameter: overrides must apply to the map that is actually STORED, after
+  # the hardcoded-mode filter - same layering as before, when the hardcoded set
+  # itself arrived through the setter's parameter (user override > any rollout).
   if result.contains("=(globalThis.__cdbApplyGbOverrides||"):
     echo "  [OK] features-store setter already hooked"
     inc patchesApplied
   else:
     let setterPat = nre.re(
-      r"""(function [\w$]+\(([\w$]+)\)\{)((?:const|let|var) [\w$]+=[\w$]+;[\w$]+=\2,[\w$]+=!0;(?:const|let|var) [\w$]+=Object\.keys\([\w$]+\)\.length[^"`]{0,200}["`]\[growthbook\] loaded %d features \(%d changed\)["`])"""
+      r"""(function [\w$]+\(([\w$]+),[\w$]+\)\{[\w$]+=[\w$]+;(?:const|let|var) [\w$]+=[\w$]+;[\w$]+=)([\w$]+\(\2\))(;(?:const|let|var) [\w$]+=Object\.keys\([\w$]+\)\.length[^"`]{0,200}["`]\[growthbook\] loaded %d features \(%d changed\)["`])"""
     )
     var hooked = 0
     let m = result.find(setterPat)
     if m.isSome:
       let cap = m.get.captures
-      let head = cap[0]
-      let param = cap[1]
-      let body = cap[2]
+      let head = cap[0]        # "function F(e,t){OS=t;let n=DS;DS="
+      let transformCall = cap[2]  # "jit(e)"
+      let tail = cap[3]        # ";let r=Object.keys(DS).length...loaded %d features..."
       let hook =
-        head & param & "=(globalThis.__cdbApplyGbOverrides||function(x){return x})(" &
-        param & ");" & body
+        head & "(globalThis.__cdbApplyGbOverrides||function(x){return x})(" &
+        transformCall & ")" & tail
       result = result.replace(m.get.match, hook)
       hooked = 1
     if hooked == 1:

--- a/scripts/tests/community/test-diff-views-expand-dom.mjs
+++ b/scripts/tests/community/test-diff-views-expand-dom.mjs
@@ -121,7 +121,24 @@ const FIXTURES = {
   empty: fixture([], '<div class="diffs-container"></div>'),
   // headers exist but none exposes aria-expanded: nothing has loaded (or the
   // upstream attribute contract changed).
-  nostate: fixture([header("f1", null), header("f2", null)])
+  nostate: fixture([header("f1", null), header("f2", null)]),
+  // The in-app browser panel as an EMPTY "New tab": a real .epitaxy-view-panel
+  // with a chrome row and close control, ZERO diff markers, and - crucially - no
+  // iframe/webview yet, so the negative surface check cannot tell it from an
+  // emptied diff. Measured live 2026-08-21 (Claude Desktop 1.32352.1): with
+  // Branch changes applied, exactly this shape carried our dropdown
+  // (wrapperTileId=preview, hasDiffMarkers=false, nonDiffSurface=false,
+  // ourDropdown=true). The only honest discriminator is the React fiber's
+  // memoizedProps.tileId, which the "leak" scenario wires the same way the live
+  // page carries it (observed at hops 3-5 above the view-panel node).
+  browser: `
+<div class="epitaxy-view-panel" id="view">
+  <div class="chromerow" id="row">
+    <span class="crumb" id="crumb">New tab</span>
+    <button type="button" id="close" class="epitaxy-pane-close-control shrink-0 text-t5" aria-label="Close" title="Close panel"><svg viewBox="0 0 16 16"><path d="M2 2l12 12"/></svg></button>
+  </div>
+  <div class="browserbody" id="browserbody"></div>
+</div>`
 };
 
 // --- the in-page test driver ----------------------------------------------
@@ -680,6 +697,67 @@ async function run() {
      "still gone a sweep later - the install loop does not put one back into a " +
      "view that does not qualify");
 }`,
+  // THE DROPDOWN LEAK (2026-08-21, measured live on 1.32352.1): with a
+  // non-working scope applied, the diff-scope dropdown mounted in the in-app
+  // browser panel's chrome row - and in the Files panel the same way. Unlike
+  // DEFECT B this is a genuine MIS-INSTALL, not a stale leftover: an empty "New
+  // tab" has no iframe yet, so qualifiesAsEmptyDiffView's negative surface check
+  // passes and the mode gate is open because the user really did apply Branch
+  // changes (in the diff panel). The fix is a POSITIVE identity gate: the fiber's
+  // memoizedProps.tileId must say "diff" before the empty-diff fallback fires.
+  // A null tileId (unreadable fiber) falls back to the old gates so the
+  // dead-end rescue survives a React internals change.
+  leak: String.raw`
+async function run() {
+  var view = document.getElementById("view");
+  // The fiber, shaped as measured live: tileId sits on an ANCESTOR fiber node,
+  // not on the element's own memoizedProps.
+  var FIBER = "__reactFiber$leaktest";
+  view[FIBER] = { memoizedProps: {}, return: { memoizedProps: { tileId: "preview" }, return: null } };
+
+  ok(document.querySelectorAll(".cdb-dv-select").length === 0,
+     "precondition: a marker-less browser panel gets nothing in Working tree");
+
+  // The user applies Branch changes (in the real diff panel elsewhere): main's
+  // effective mode goes non-working, which is GATE 1 of the empty-diff fallback.
+  window.__stubMode = "branch";
+  await sleep(150);                        // several 10ms pref polls + the mode-change sweep
+  view.appendChild(document.createElement("span"));
+  await sleep(900);                        // one debounced sweep
+  ok(document.querySelectorAll(".cdb-dv-select").length === 0,
+     "LEAK GUARD: an empty in-app browser tab (no iframe, tileId=preview) gets NO " +
+     "dropdown even with a non-working scope applied: " +
+     document.querySelectorAll(".cdb-dv-select").length);
+
+  // The dead-end rescue must SURVIVE the fix: the same zero-marker shape whose
+  // fiber says tileId=diff IS the diff view our own scope emptied, and without a
+  // dropdown there is no way back to Working tree.
+  view[FIBER].return.memoizedProps.tileId = "diff";
+  view.appendChild(document.createElement("span"));
+  await sleep(900);
+  ok(document.querySelectorAll(".cdb-dv-select").length === 1,
+     "the emptied DIFF view (tileId=diff, zero markers) still gets its dropdown: " +
+     document.querySelectorAll(".cdb-dv-select").length);
+
+  // Upstream hands this row to the browser tile again: the re-validation sweep
+  // must now strip the dropdown off it (this is the exact live state measured
+  // 2026-08-21 - ourDropdown:true on tileId=preview).
+  view[FIBER].return.memoizedProps.tileId = "preview";
+  view.appendChild(document.createElement("span"));
+  await sleep(900);
+  ok(document.querySelectorAll(".cdb-dv-select").length === 0,
+     "re-validation strips the dropdown once the fiber identity stops being diff: " +
+     document.querySelectorAll(".cdb-dv-select").length);
+
+  // And with the fiber UNREADABLE the old gates still carry the rescue: an
+  // emptied diff whose fiber upstream renamed must not become a dead end.
+  delete view[FIBER];
+  view.appendChild(document.createElement("span"));
+  await sleep(900);
+  ok(document.querySelectorAll(".cdb-dv-select").length === 1,
+     "null tileId falls back to the legacy gates - the dead-end rescue outlives " +
+     "a React internals rename: " + document.querySelectorAll(".cdb-dv-select").length);
+}`,
   destroy: String.raw`
 async function run() {
   var t = toggle();
@@ -768,8 +846,12 @@ window.__diag = [];
 window.__cdbDvTestPollMs = 10;   // TEST-ONLY override documented in diff_views_page.js
 window.cdbDiffViews = {
   state: function () {
+    // __stubMode lets a scenario apply a non-working scope the way the real main
+    // process would report one (the "leak" scenario needs Branch changes active
+    // to open the qualifiesAsEmptyDiffView gate). Default unchanged: working.
     return Promise.resolve({ ok: true, available: true, isGitRepo: true,
-                             enabled: true, mode: "working", hasTurnSnapshot: false });
+                             enabled: true, mode: window.__stubMode || "working",
+                             hasTurnSnapshot: false });
   },
   setMode: function () { return Promise.resolve({ ok: true, nudged: true }); }
 };
@@ -846,7 +928,8 @@ const scenarios = [
   ["reattach", FIXTURES.mixed, RUNS.reattach, null],
   ["fullscreen", FIXTURES.mixed, RUNS.fullscreen, null],
   ["destroy", FIXTURES.mixed, RUNS.destroy, null],
-  ["stale", FIXTURES.mixed, RUNS.stale, null]
+  ["stale", FIXTURES.mixed, RUNS.stale, null],
+  ["leak", FIXTURES.browser, RUNS.leak, null]
 ];
 
 let pass = 0;

--- a/scripts/tests/community/test-panel-tabs-dom.mjs
+++ b/scripts/tests/community/test-panel-tabs-dom.mjs
@@ -75,12 +75,21 @@ const paneHtml = (t) => `
 //   chat's shell   position:absolute (inline: top/bottom/left:0, min-width:320px), EMPTY
 //   a side shell   position:static   (no `position` in its inline style at all), 1 pane
 //
+// RE-MEASURED 2026-08-21 (1.32352.1, remote claude.ai redeploy): the chat shell is no
+// longer literally empty. It now carries an `aria-hidden="true"` .epitaxy-view-panel
+// GHOST (no [data-pane-root], no fiber tileId, no close control) alongside the chat UI.
+// That single node is what broke the feature in the field: chatLooksRight()'s
+// "every shell empty of both pane anchors" test failed every frame, no-chat-column
+// warned, and the bar never armed. The fixture therefore ships the ghost - a suite
+// whose chat shell stayed empty would green-light the exact DOM that is broken live.
+//
 // That is the discriminator `chatLooksRight()` uses to tell the chat column from a side
 // wrapper whose pane has not landed yet, so a fixture that gave chat a STATIC shell would
 // be testing a DOM upstream does not produce - and would let a mis-identification pass.
 // The wrappers get `position:relative` because upstream's do (measured inline:
 // `position: relative; min-width: 100px; ...`), which is what contains the absolute shell.
-const CHAT_SHELL = `<div class="tiles-shell" style="position:absolute;top:0;bottom:0;left:0;width:100%;height:100%"></div>`;
+const CHAT_GHOST = `<div class="epitaxy-view-panel rounded-card bg-surface-2" aria-hidden="true" data-test-ghost="">ghost</div>`;
+const CHAT_SHELL = `<div class="tiles-shell" style="position:absolute;top:0;bottom:0;left:0;width:100%;height:100%">${CHAT_GHOST}</div>`;
 const sideShell = (t) => `<div class="tiles-shell" style="height:100%">${paneHtml(t)}</div>`;
 
 // The column row. tiles[0] is expected to be "chat": its column keeps an EMPTY,
@@ -763,6 +772,36 @@ const SINK = 'document.getElementById("__result").textContent = JSON.stringify';
   ok(r.writes === 0 && r.warns === 1,
      "safety: it warns and touches nothing (no layout write of any kind)");
   ok(r.chatVisible === true, "safety: the shared column stays visible");
+}
+{
+  // THE GHOST EXCEPTION MUST NOT WEAKEN THE DECOY DEFENSE (2026-08-21). The chat
+  // shell's aria-hidden view-panel ghost is ignored when testing shell emptiness -
+  // but a NON-hidden .epitaxy-view-panel (e.g. a real pane mid-mount, before its
+  // [data-pane-root] lands) still counts as occupancy. A first-row-child decoy
+  // carrying one, in an otherwise chat-shaped absolute shell, must never be picked
+  // as the chat column - and the REAL (ghost-carrying) chat column must still be.
+  const r = run(withPage(["chat", "diff"], `
+    var P = window.__cdbTabsPage;
+    P.setEnabled(true); P.reconcile(); P.renderBar();
+    var chatMarks = document.querySelectorAll("[data-cdb-chat]");
+    ${SINK}({ chatMarkCount: chatMarks.length,
+      chatMarkOn: chatMarks.length === 1 ? chatMarks[0].getAttribute("data-test-col") : null,
+      active: window.__activeCol(), bar: P.barEl() !== null,
+      decoyTag: document.querySelector('[data-test-col="decoy"]').getAttribute("data-cdb-col"),
+      writes: window.__writes() });`,
+    { wrap: () => `
+      <div class="epitaxy-column" data-test-col="decoy" style="position:relative;flex: 1 1 0%;">
+        <div class="tiles-shell" style="position:absolute;top:0;bottom:0;left:0;width:100%;height:100%">
+          <div class="epitaxy-view-panel">a pane mid-mount - NOT aria-hidden</div>
+        </div>
+      </div>` + columnRow(["chat", "diff"]) }), "ghost-decoy");
+  ok(r.chatMarkCount === 1 && r.chatMarkOn === "chat",
+     "ghost decoy: the chat mark is on the REAL chat column (aria-hidden ghost ignored), " +
+     "never on the decoy whose view panel is not hidden: " + r.chatMarkOn);
+  ok(r.active === "diff" && r.bar === true,
+     "ghost decoy: the feature still arms on the real chat column - a non-hidden " +
+     "view panel disqualifies the decoy without poisoning the pick");
+  ok(r.writes === 0, "ghost decoy: zero layout writes throughout");
 }
 {
   // A side pane with no .tiles-shell ancestor: nothing to resolve, so nothing is


### PR DESCRIPTION
Three fixes (the first two broke via remote claude.ai redeploys, no desktop release involved):

- **Panel tabs never rendered:** upstream now puts an `aria-hidden="true"` `.epitaxy-view-panel` ghost inside the chat column's shell, so the chat-column detector (all shells empty) refused every frame. **Fix:** aria-hidden view panels no longer count as shell occupancy; non-hidden ones still do.
- **Diff-scope dropdown appeared in browser/Files panels:** an empty browser "New tab" (no iframe yet) passed every empty-diff fallback gate when a non-working scope was active. **Fix:** the fallback now requires the React fiber's `tileId === "diff"`; revalidation strips already-leaked dropdowns.
- **`add_growthbook_overrides` failed on v1.34493.1:** the features-store setter gained a param and now stores through the deployment-mode filter. **Fix:** hook wraps the transform call instead of the raw parameter — same override layering.

Tests: 380 + 117 DOM assertions green (3 new scenarios fail pre-fix); full local build against v1.34493.1 applies clean; anchors re-derived live over CDP and `baseline/PANEL_TABS_ANCHORS.md` updated.