### PR TITLE
feat(files-quick-open): Ctrl+P quick open over the Files panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ These files embed assumptions about upstream internals and **must be challenged 
 | `baseline/CLAUDE_BUILT_IN_MCP.md` | Built-in MCP server names, registration patterns | Check `registerInternalMcpServer` calls in new JS |
 | `js/extra_settings_main.js` (`__cdbEx_DEPLOY_KEYS`) | The managed-settings key catalog the Extra → Deployment panel renders, pinned from the bundle's own zod schema. A key upstream removes keeps being offered; a key it adds is missing. Also the faithful port of the 3p-dir resolver and the mode decision | ``rg -ao 'flatKey:[`"][A-Za-z0-9_]+[`"]' tmp/app.asar.contents/.vite/build/index.pre.js \| sort -u`` (the minifier emits backtick strings since v1.26832.0) and diff against the catalog; `node scripts/tests/core/test-deployment-main.mjs` asserts the shape |
 | `baseline/PANEL_TABS_ANCHORS.md` | Panel-tabs DOM/fiber anchors: the row shape, `MAX_CHAIN_HOPS`, the literal `"chat"` tile id, the label->tileId map (upstream's `Browser` is tile `preview`), the Session-actions menu, and the runtime warnings that mean an anchor moved | Re-run the console recipes in that file against the new build; every `[cdb-tabs]` warning key listed there names the anchor that broke |
+| `baseline/FILES_QUICK_OPEN_ANCHORS.md` | Files quick-open anchors: the `data-perf-screen="file"` pane, the tree rows, the `Show file tree` toolbar button, the fiber `onPreview(path, line)` handler with its `root` prop, the `entry` props, the `fetchMentionOptions` result shape, and the `[cdb-qopen]` warning keys | Re-run the console recipes in that file against the new build; also re-check the `FileIndexHost.search` anchor of `add_feature_files_quick_open_worker.nim` (`grep -o 'of this\.index\.search(' fileIndexWorker.js` must hit exactly once before patching). The worker-host fork that carries the `CDB_FILES_QUICK_OPEN` gate (``grep -oE 'utilityProcess\.fork\([^)]{0,120}\)' index*.js``) needs no manual check — `add_feature_files_quick_open.nim` sub-patch B rewrites it to pass `env:Object.assign({},process.env)` and its strict count (exactly one match) fails the build if the shape moves |
 | `baseline/ION.md` | ion-dist SPA bundle stats, patched patterns, config key schema | Run ion-dist checks (Prompt 4 in update-prompt.md) |
 | `baseline/PLATFORM_GATE_BASELINE.md` | darwin/win32 conditional counts, gate classifications (PATCHED/NATIVE/STUB/PORTABLE) | Run platform gate re-audit (Prompt 5 in update-prompt.md) |
 | `CHANGELOG.md` | Version-specific notes | Add new entry for each release. **One entry per day** - merge multiple changes into a single dated `##` section with subsections. **Keep notes informative, simple, and straight** - state what changed and the conclusion; don't dump verification minutiae, raw diffs, byte counts, or every minified identifier. The CHANGELOG is a reader's summary, not a debug log. |
@@ -331,20 +332,20 @@ git push
 ```
 patches/           # Nim patch sources (.nim) + Makefile, compiled to native binaries (ls patches/*/*.nim)
 patches/linux/     #   Linux compatibility - always on, not user-configurable (31)
-patches/community/ #   Opt-in features, each with a switch in Settings -> Extra -> Community Features (6)
+patches/community/ #   Opt-in features, each with a switch in Settings -> Extra -> Community Features (9)
 patches/core/      #   Always-on infrastructure the rest builds on: the Extra settings pages, the theme
                    #   engine, the GrowthBook override mechanism, multi-profile plumbing (7)
 js/                # Shared JS snippets embedded by Nim patches via staticRead ("../../js/..." from a patch)
 scripts/           # Build, validation, and launcher scripts (ls scripts/)
 scripts/tests/     # Feature test harnesses, grouped like patches/ (run: scripts/run-feature-tests.sh)
-scripts/tests/community/ #   Behavior tests for the opt-in community features (5)
+scripts/tests/community/ #   Behavior tests for the opt-in community features (8)
 scripts/tests/core/      #   Behavior tests for the core infrastructure features (5)
 scripts/tests/linux/     #   Behavior tests for the Linux compatibility patches (1)
 scripts/tests/lib/       #   Shared harness plumbing (theme-engine-harness.mjs), not tests themselves
 docs/              # Per-feature deep-dives (themes, profiles, quick-entry, cowork, feature-flags,
                    #   computer-use, third-party-inference, environment-variables) + screenshots.
                    #   The README carries only a teaser per feature and links here.
-baseline/          # Version-sensitive reference docs re-validated against the bundle each release: CLAUDE_FEATURE_FLAGS.md, CLAUDE_BUILT_IN_MCP.md, ION.md, PLATFORM_GATE_BASELINE.md, PANEL_TABS_ANCHORS.md
+baseline/          # Version-sensitive reference docs re-validated against the bundle each release: CLAUDE_FEATURE_FLAGS.md, CLAUDE_BUILT_IN_MCP.md, ION.md, PLATFORM_GATE_BASELINE.md, PANEL_TABS_ANCHORS.md, FILES_QUICK_OPEN_ANCHORS.md
 ```
 
 Each patch has a `# @patch-target:` and `# @patch-type: nim` header. The Makefile compiles them to native binaries. The orchestrator (`scripts/apply_patches.py`) discovers them recursively across the three subdirectories and applies them in **basename order** (the directory only classifies a patch, it does not order it). Use `ls patches/*/*.nim` as the single source of truth for what exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to the claude-desktop-extra packages will be documented in this file.
 
+## 2026-08-30
+
+### Files quick open: no need to open the Files panel first
+
+Ctrl+P now works with the Files panel closed. It opens the panel through Anthropic's own session
+menu (⋮ → Files), waits for it, and opens the file you pick — so the shortcut is the only thing you
+have to remember. The panel is only ever opened when there is none: that menu entry is a toggle, and
+pressing it with a panel already open would close the one the feature needs. Upstream's own Ctrl+F
+accelerator cannot be reused for this — a key event sent from the page is untrusted and does nothing —
+so the menu is driven directly, and no menu is ever left hanging over the app.
+
+The handler the modal opens files through is now found by descending from the panel rather than by
+walking up from a tree row. A panel that has just been created renders its tree with no rows at all
+for a few seconds, and the old walk had nothing to start from; the descent finds the same handler
+(and the folder it was rendered for) whether or not a single row exists yet.
+
+## 2026-08-29
+
+### Files quick open (new community feature)
+
+**Ctrl+P over the Files panel.** A new opt-in switch in Settings → Extra → Community Features adds a
+VS Code-style quick-open box to the Code tab: type part of a file name, move with the arrow keys or
+the mouse, press Enter and the file opens as a tab inside the Files panel (the same path a click on
+the tree takes); `name:42` opens at a line, and an empty query lists recently opened files. The box
+asks Anthropic's own file index, so results and highlighting match the panel's filter and the
+composer's `@` picker. It needs the Files panel open and stays out of the way of a focused terminal.
+If the panel is open but its file tree is collapsed, Ctrl+P presses Anthropic's own "Show file tree"
+button first and opens the box as soon as the tree is back - that is also the only state in which the
+panel exposes no way to open a file at all. The box waits for the tree's *rows*, not just the tree,
+and keeps looking for a few seconds: the panel paints the empty tree first, and the way in to opening
+a file only exists once a row is on screen.
+
+**Spaces in a file search now mean "and".** Anthropic's fuzzy file index treated a space as a
+character to find, so `user service` returned nothing while `user-service` worked. With the
+switch on, the index splits the query into pieces that must all match, in any order, and merges the
+highlights - the way VS Code's quick open scores multi-word queries. This reaches the Files panel's
+filter and the `@` picker too. Off leaves the index exactly as shipped.
+
+**Multi-word results are ranked by file name.** The pieces of a multi-word query are matched
+separately, and merging them by the index's own per-piece ordering put whole directories above the
+file being looked for - `user service` led with three unrelated sibling folders and
+`user service spec` did not show `user-service.spec.ts` at all. Matches are now scored the way
+VS Code scores them, on the file name first and the folder only as a fallback, with short names and
+shallow paths preferred. Which files match is unchanged - only their order.
+
+The switch reaches the index through an environment variable, and Electron hands a utility process
+the app's *initial* environment unless the fork asks for the current one - so a patch now makes
+Anthropic's worker host pass the live environment explicitly. Without it the switch was set in the
+main process and never seen by the index. It still applies to file-index workers started after the
+switch flips (a running one keeps what it was born with until it restarts, or the app does).
+
+Three patches (`add_feature_files_quick_open`, `_bridge`, `_worker`), three test harnesses, and a new
+`baseline/FILES_QUICK_OPEN_ANCHORS.md` with the remote-DOM anchors the box depends on.
+
 ## 2026-08-26
 
 ### Claude Desktop v1.37937.0

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -18,7 +18,7 @@ Each row below says what a patch does and why you would want it. The mechanism -
 
 ## Community features
 
-**6 patches**, each with a switch in Settings → **Extra** → **Community Features**. They reshape first-party surfaces, so they are asked for rather than assumed: turning one off is a full retreat to upstream's own behavior. Off by default, except the theme picker.
+**9 patches**, each with a switch in Settings → **Extra** → **Community Features**. They reshape first-party surfaces, so they are asked for rather than assumed: turning one off is a full retreat to upstream's own behavior. Off by default, except the theme picker.
 
 | Patch | What it does & why it exists |
 |-------|------------------------------|
@@ -28,8 +28,11 @@ Each row below says what a patch does and why you would want it. The mechanism -
 | [`add_feature_diff_views_bridge.nim`](patches/community/add_feature_diff_views_bridge.nim) | The narrow preload bridge the diff dropdown talks through: one fixed channel per call, because the page behind it is remote code |
 | [`add_feature_panel_tabs.nim`](patches/community/add_feature_panel_tabs.nim) | Turns the Code tab's side panels into a tab strip instead of a shrinking split, so each panel gets the full width and keeps its state when you switch away |
 | [`add_feature_panel_tabs_bridge.nim`](patches/community/add_feature_panel_tabs_bridge.nim) | The narrow preload bridge the tab strip talks through: one fixed channel per call, because the page behind it is remote code |
+| [`add_feature_files_quick_open.nim`](patches/community/add_feature_files_quick_open.nim) | <kbd>Ctrl</kbd>+<kbd>P</kbd> on the Code tab opens a VS Code-style quick-open box over the Files panel; arrow keys or mouse, <kbd>Enter</kbd> opens the file as a tab in the panel, `:42` jumps to a line, an empty query lists recently opened files |
+| [`add_feature_files_quick_open_bridge.nim`](patches/community/add_feature_files_quick_open_bridge.nim) | The narrow preload bridge the quick-open box talks through: one fixed channel per call, because the page behind it is remote code |
+| [`add_feature_files_quick_open_worker.nim`](patches/community/add_feature_files_quick_open_worker.nim) | Teaches Anthropic's fuzzy file index VS Code's space-separated pieces - `user service` finds `user-service.spec.ts`, in any word order. Upstream treats the space as a character to find and returns nothing. Also fixes the Files panel's own filter and the composer's `@` picker. Gated by an env var read at worker start, so flipping the switch reaches the file index on its next start (after a restart) |
 
-Panel tabs depends on DOM anchors in remote claude.ai code; they are inventoried with re-derivation recipes in [`baseline/PANEL_TABS_ANCHORS.md`](baseline/PANEL_TABS_ANCHORS.md) and re-validated on each upstream bump.
+Panel tabs and Files quick open depend on DOM anchors in remote claude.ai code; they are inventoried with re-derivation recipes in [`baseline/PANEL_TABS_ANCHORS.md`](baseline/PANEL_TABS_ANCHORS.md) and [`baseline/FILES_QUICK_OPEN_ANCHORS.md`](baseline/FILES_QUICK_OPEN_ANCHORS.md) and re-validated on each upstream bump.
 
 ## Core infrastructure
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ This package adds its own section to Claude's Settings dialog: **Extra** - the h
 Four panels today:
 
 - **Extra → Themes** - all **97 bundled palettes** with live color dots; one click applies instantly in every open window. Make Claude Desktop blend into your Linux desktop: palettes matching stock DE looks (ADW/Adwaita, Breeze) sit next to the classics (Catppuccin, Nord, Gruvbox, Rose Pine, Everforest) and a [Gaming collection](docs/themes.md).
-- **Extra → Community Features** - the **4 optional features** this project currently adds, each as a switch ([6 patches](PATCHES.md#community-features): panel tabs, diff view modes, the theme-picker hotkey, a calmer Cowork glow), with a filter box over them.
+- **Extra → Community Features** - the **5 optional features** this project currently adds, each as a switch ([9 patches](PATCHES.md#community-features): Files quick open, panel tabs, diff view modes, the theme-picker hotkey, a calmer Cowork glow), with a filter box over them.
+  - **Files quick open** - <kbd>Ctrl</kbd>+<kbd>P</kbd> on the Code tab opens a VS Code-style quick-open box over the Files panel. Type part of a name - spaces split the query into pieces that must all match, in any order, so `user service` finds `user-service.spec.ts` - pick with the arrow keys or the mouse, and <kbd>Enter</kbd> opens it as a file tab in the panel; `:42` jumps to a line, an empty query lists what you opened recently. The same fix reaches the Files panel's own filter and the composer's `@` file picker. Opt-in: Settings → Extra → Community Features - the hotkey applies live, the spaces fix reaches the file index on its next start (after a restart).
 - **Extra → Anthropic Features** - all **134 upstream [feature flags](#feature-flag-overrides-advanced)** this build reads, each as a switch - no config-file editing needed.
 - **Extra → Deployment** - a **1P / 3P switch** plus the whole [third-party inference](#third-party--enterprise-inference) configuration as toggles and fields. Turning 3P on used to be a one-way door without a root shell; here it is a button, and every value is written to your own profile directory.
 
@@ -346,7 +347,7 @@ The official 3P docs cover only macOS and Windows. **[docs/third-party-inference
 
 The official Linux build ships one cross-platform JS bundle that gates plenty of features to macOS and Windows, and some of its behavior misfires on a Linux desktop. We apply a set of surgical JS patches to the `app.asar` at repackage time - one directory per purpose:
 
-- **[`patches/community/`](PATCHES.md#community-features)** (6 patches) - optional features you switch on yourself in Settings → **Extra** → **Community Features**. Off unless you ask for them (the theme picker is the exception, on by default).
+- **[`patches/community/`](PATCHES.md#community-features)** (9 patches) - optional features you switch on yourself in Settings → **Extra** → **Community Features**. Off unless you ask for them (the theme picker is the exception, on by default).
 - **[`patches/core/`](PATCHES.md#core-infrastructure)** (7 patches) - always-on infrastructure the rest builds on: the Extra settings pages themselves, the theme engine, the flag-override mechanism, and the multi-profile plumbing.
 - **[`patches/linux/`](PATCHES.md#linux-compatibility)** (31 patches) - upstream features still gated to macOS/Windows in the shared bundle, or that break in a Linux environment. Always on, nothing to configure.
 

--- a/baseline/FILES_QUICK_OPEN_ANCHORS.md
+++ b/baseline/FILES_QUICK_OPEN_ANCHORS.md
@@ -1,0 +1,92 @@
+# Files quick open - remote anchors
+
+Measured live over CDP against Claude Desktop **v1.37937.3**, and **re-measured on v1.40609.0**
+(both claude.ai/epitaxy) on **2026-08-29**. The page half (`js/files_quick_open_page.js`) keys off
+REMOTE claude.ai markup and React fiber props. None of these strings occur in `app.asar`; re-run the
+recipes below against the live app after an upstream bump or when a `[cdb-qopen]` warning appears in
+`~/.config/Claude/logs/claude.ai-web.log`.
+The one exception is the last row — the generic worker-host fork — which lives in the LOCAL main
+bundle, is rewritten by `add_feature_files_quick_open.nim` sub-patch B, and is checked with grep
+rather than the console.
+
+## Anchors
+
+| Anchor | Used for | Measured value | If it moves |
+|---|---|---|---|
+| `[data-pane-root][data-perf-screen="file"]` | the Files pane (`PANE_SEL`) | tile id `file` (NOT `browser`, which `baseline/PANEL_TABS_ANCHORS.md` recorded earlier); header text `Files` | modal shows "Open the Files panel first" although the pane is open → update `PANE_SEL` |
+| `input[aria-label="Filter files"]` | fiber entry point of last resort (`FILTER_SEL`) | placeholder `Filter files… (? to search contents)`; the walk up from it returned **null** on 1.40609.0 | kept only as a fallback start - it resolves nothing today, so it must never be treated as "the harvest succeeded" |
+| `[role="tree"]` / `[role="treeitem"]` | fallback fiber entry points (`TREE_SEL`, `ROW_SEL`) and the tile-root derivation | virtualized: ~46 rows in DOM regardless of tree size. On a COLD render the `[role=tree]` element commits BEFORE its rows, and a pane opened from scratch renders the tree with **0 rows for seconds** - the descent below is what covers both | warning `no-onpreview` |
+| `button[aria-label="Show file tree"]` | un-hiding a collapsed tree (`SHOW_TREE_SEL`) | on 1.40609.0 a Files pane can show an open file with the tree collapsed: no `[role=tree]`, no rows, no filter box, and a BFS over 1581 fibers finds NO `onPreview`. The toolbar button carries `aria-pressed="false"`; a real `.click()` renders the tree (46 rows + filter) within ~700 ms and relabels it `Hide file tree` | the page polls the HARVEST for `TREE_WAIT_MS` (3000 ms) and then degrades to `HINT_NO_HANDLER`; warnings `harvest-timeout` / `show-tree-threw`. A relabel (e.g. "Show files") means updating `SHOW_TREE_SEL` |
+| fiber component with `memoizedProps.onPreview` | opening a file, and the tile root | `function (path: string, line?: number, findQuery?: string)`. **Found by DESCENDING from the pane root** (breadth-first, depth 10 after ~55 fibers, measured 2026-08-30 on 1.40609.0) - that is the only strategy that works while the tree has rendered NO rows, which is how a freshly opened pane starts and stays for seconds. Walking UP from a `[role="treeitem"]` ROW also reaches it (hop ~12) and is kept as the fallback; walking up from `[role="tree"]` or from `input[aria-label="Filter files"]` returns null. The owning component's props are `{sessionId, root, reveal, listDirectory, scope, remote, scrollEl, navRef, onPreview, prefetcher}`. The owning component's string `root` prop (the tile's folder, NO trailing slash) is the tile root, preferred over the row-derived one. Passing an object to `onPreview` throws `e.startsWith is not a function` | warning `no-onpreview` / `onpreview-threw`; hint "Cannot open files"; a missing `root` prop falls back to the `entry` row below |
+| row fiber `memoizedProps.entry` | tile root = `absPath` minus `relativePath` | `{name, absPath, relativePath, isDirectory, positions}` | root falls back to the index's absolute path; MRU disabled; warning `no-entry` |
+| `window["claude.web"].Resources.fetchMentionOptions(q, "files")` | search | ≤ 50 `{id: "file-<abs>", label: "<rel>", icon, category: "Files", metadata: JSON {path, isDirectory, positions}}`, ~90 ms; rooted at the FOCUSED session cwd | warning `search-*`; hint "Search unavailable" |
+| `MENU_SEEDS` → `SESSION_MENU_SEL` → the `Files` entry | creating a Files pane when none is open | The session ⋮ is `button[aria-label^="More options for "]`, but ~76 of those exist (one per sidebar session), and it is **not** a sibling of the `Terminal` / `Diff (uncommitted changes)` / `Browser` toolbar buttons. Measured 2026-08-30 on 1.40609.0: climbing from one of those buttons, the ancestor **2 parents up** holds exactly one - that climb (`MENU_CLIMB_HOPS`, refuses on >1 match) is the anchor. Its menu renders async and its entry reads **`FilesCtrlF`** (label + shortcut, no separator, hence the `/^files/i` prefix test); clicking it mounts the pane in ~900 ms. The entry is a **TOGGLE** - only ever pressed when there is no pane. Upstream's own `Ctrl+F` accelerator is unusable from the page: a synthetic key event is untrusted and does nothing. **Nothing the page can dispatch closes that menu either** (measured 2026-08-30: Escape on body/document/the menu itself, an outside pointerdown, and a second click on the ⋮ all leave it open) - it stays mounted behind our own full-screen overlay and disappears together with it when the modal closes, so no menu is ever left over the app. `dismissMenu()` is a best-effort attempt kept for other builds, not a guarantee | the modal degrades to `HINT_NO_PANE`; warnings `no-files-menu-item` / `session-menu-threw` / `files-item-threw`. A relabelled entry means updating `FILES_ITEM_RE` |
+| `Ctrl+P` | hotkey | unbound in upstream's Electron menu (only `CmdOrCtrl+Plus` matches the substring); renderer bindings unknown, hence the capture-phase listener | a conflict shows up as both actions firing - re-check `mainView`/renderer |
+| generic worker-host fork (LOCAL bundle) | the `CDB_FILES_QUICK_OPEN` env gate reaches the file-index worker | `utilityProcess.fork(<path>,[],{serviceName:<name>,stdio:\`pipe\`})` - exactly ONE occurrence in the staged bundle (1.37937.3 and 1.40609.0), the host that `worker:{buildName:\`file-index-worker\`` uses. `add_feature_files_quick_open.nim` **sub-patch B rewrites it** to add `env:Object.assign({},process.env)`, because Electron hands a `fork()` with no `env` option the browser's INITIAL environment, not main's live `process.env` (measured live: the key was in main's `/proc/<pid>/environ` and in none of the utility processes). Passing main's LIVE env also forwards whatever upstream writes into it after startup — measured on 1.37937.3: `CLAUDE_CODE_SESSION_ACCESS_TOKEN` and `CLAUDE_CONFIG_DIR` — to every worker that host spawns (file-index, transcript-search, heavy-work, stall-sampler), which the initial-env default did not; same user, same app, so an exposure-surface widening rather than a boundary crossing | the patch **fails the build** (strict count: exactly one match required), so this cannot regress silently. If upstream adds its own `env:` there, merge into it instead of prepending a second key |
+
+## The harvest is row-driven, and it retries
+
+`onPreview` is reachable only from a `[role="treeitem"]` row, so the page cannot use the DOM as its
+wait condition: on a COLD render (tree hidden since app start) the `[role=tree]` element commits
+first and its rows land ~200-700 ms later. Waiting on "a tree or a row exists" therefore harvested
+nothing, gave up for good, and Enter opened nothing — the live defect measured on 1.40609.0.
+
+`js/files_quick_open_page.js` polls `findPreviewProps()` itself every `TREE_POLL_MS` (50 ms) up to
+`TREE_WAIT_MS` (3000 ms) and finishes the moment it returns non-null. The same retry covers the
+non-deferred path (a visible tree with zero rows — an empty folder, or upstream's own filter matched
+nothing). A `memoizedProps` accessor that THROWS is final, not "not yet": the retry stops, `open-threw`
+is warned once and the hint says the anchor is gone.
+
+## Verifying the `CDB_FILES_QUICK_OPEN` env gate
+
+**`/proc/<pid>/environ` is not a valid probe.** Chromium empties the environ block of its utility
+processes — reading it yields `disable-logging` plus NULs regardless of what the process actually
+inherited — so it can neither confirm nor refute that the key reached the file-index worker (it
+produced a false negative on 2026-08-29). The **behavioural** check is the instrument: with the pref
+on, run recipe 3 below with a two-word query,
+`window["claude.web"].Resources.fetchMentionOptions("user service", "files")`. Multi-piece hits
+(50 results, and the same set for the reversed query) mean the gate is on in the worker; zero hits
+mean it is not.
+
+## Console recipes (DevTools on the claude.ai webContents, or CDP `Runtime.evaluate`)
+
+```js
+// 1. Pane + tile id
+p = document.querySelector('[data-pane-root][data-perf-screen="file"]'); p && p.getAttribute("data-perf-screen")
+// 2. onPreview signature, harvested like the page does
+f = Object.entries(p.querySelector('[role=treeitem]')).find(([k]) => k.startsWith("__reactFiber$"))[1];
+for (i = 0; f && i < 60; i++, f = f.return) if (f.memoizedProps && typeof f.memoizedProps.onPreview === "function") { console.log(f.memoizedProps.onPreview.toString().slice(0, 200)); break; }
+// 3. Index shape
+window["claude.web"].Resources.fetchMentionOptions("readme", "files").then(r => console.log(r.length, r[0]))
+// 4. Is the tree hidden? (then Ctrl+P clicks this button and waits for the tree)
+b = p.querySelector('button[aria-label="Show file tree"]'); b && b.getAttribute("aria-pressed")
+// 5. The tile root the handler was rendered for
+for (i = 0, f = Object.entries(p.querySelector('[role=treeitem]')).find(([k]) => k.startsWith("__reactFiber$"))[1]; f && i < 60; i++, f = f.return) if (f.memoizedProps && typeof f.memoizedProps.onPreview === "function") { console.log(f.memoizedProps.root); break; }
+```
+
+## Grep recipe - the generic worker-host fork (env passthrough)
+
+Run in the extracted bundle (`tmp/app.asar.contents*/.vite/build/`). The host that `file-index-worker`
+runs on is where sub-patch B injects `env:`; `CDB_FILES_QUICK_OPEN` reaches the worker only because of
+that injection (a fork with no `env` option gets the browser's INITIAL environment, so the key we set
+at runtime never arrives).
+
+```bash
+# 1. Which chunk hosts the file-index worker
+grep -l 'buildName:`file-index-worker`' index*.js
+# 2. Every fork call site - the one with serviceName + stdio is OUR anchor (exactly one)
+grep -oE 'utilityProcess\.fork\([^)]{0,120}\)' index*.js | sort -u
+#    measured 1.37937.3 + 1.40609.0, UNPATCHED:
+#      utilityProcess.fork(r,[],{serviceName:t,stdio:`pipe`})   <- generic worker host  (sub-patch B rewrites this)
+#      utilityProcess.fork(e,t,{...a,env:s})                    <- MCP host             (upstream already passes env)
+#      utilityProcess.fork(e,[],{serviceName:`Claude Desktop Shell Environment Extractor`})
+# 3. After patching, the anchor reads:
+#      utilityProcess.fork(r,[],{serviceName:t,stdio:`pipe`,env:Object.assign({},process.env)})
+```
+
+If the anchor shape changes, the patch fails the build with `expected exactly 1 generic worker-host
+fork site` - fix the pattern rather than dropping the sub-patch, or the spaces fix goes silently dead.
+
+## Warning keys → anchor
+
+`no-onpreview` (the harvest ran out of retries: no row fiber carries `onPreview`), `harvest-timeout` (same event, from the poll itself - no handler appeared within `TREE_WAIT_MS`; the two fire together), `onpreview-threw` (signature changed), `no-entry` (rows render but none carries `entry.absPath`/`relativePath` - tile root unknown, MRU disabled), `open-threw` (a fiber walk threw while harvesting; the retry stops there), `show-tree-threw` (clicking "Show file tree" threw), `no-files-menu-item` (the session menu opened but has no Files entry), `session-menu-threw` / `files-item-threw` (driving the menu threw), `search-bridge` / `search-threw` / `search-shape` / `search-rejected` (`fetchMentionOptions` moved or changed), `pref-threw` / `pref-shape` (our own bridge, not upstream).

--- a/js/extra_settings_bridge.js
+++ b/js/extra_settings_bridge.js
@@ -99,6 +99,16 @@
       return ipcRenderer.invoke("cdb-tabs:pref-set", enabled === true);
     },
 
+    // Files quick open (Ctrl+P over the Code tab's Files panel). BOTH channels are
+    // owned by patches/community/add_feature_files_quick_open.nim, not by the
+    // settings patch - the same cross-patch arrangement as panelTabsRead/Set.
+    quickOpenRead: function () {
+      return ipcRenderer.invoke("cdb-qopen:pref-read");
+    },
+    quickOpenSet: function (enabled) {
+      return ipcRenderer.invoke("cdb-qopen:pref-set", enabled === true);
+    },
+
     // Deployment mode (1P / 3P) and the third-party configuration the app boots
     // from. deployMode() takes only "1p"/"3p"; deploySet() only keys the main
     // side finds in its own catalog, and stored secrets never come back through

--- a/js/extra_settings_page.js
+++ b/js/extra_settings_page.js
@@ -1075,6 +1075,40 @@
     });
   }
 
+  // --- files: Ctrl+P quick open over the Files panel -------------------------
+  // Ours, opt-in, and off by default: it adds a hotkey and a search box over
+  // Anthropic's own Files panel and changes how the file index treats spaces.
+  // The hotkey applies live; the index half applies to file-index workers
+  // started after the switch flips (upstream restarts them on cwd change / idle),
+  // so the note says "or after a restart" rather than pretending it is instant.
+  function renderFilesQuickOpenRow(panel) {
+    return renderToggleRow(panel, {
+      section: "Files",
+      title: "Files quick open",
+      note: "Ctrl+P on the Code tab opens a VS Code-style quick-open box over the Files panel: " +
+        "type part of a name, use the arrow keys or the mouse, press Enter to open it as a file tab. " +
+        "Spaces split the query into pieces that must all match, in any order - 'user service' " +
+        "finds user-service.spec.ts - and that also fixes the Files panel's own filter and the " +
+        "composer's @ file picker. Off leaves the panel and the index exactly as Anthropic ships them. " +
+        "The hotkey applies live; the spaces fix reaches the file index on its next start or after a restart.",
+      ariaLabel: "open files with Ctrl+P from a quick-open box over the Files panel",
+      read: "quickOpenRead",
+      write: "quickOpenSet",
+      lockFile: "claude-desktop-extra.jsonc",
+      isOn: function (res) { return res.enabled === true; },
+      describe: function (on) {
+        return on ? "on - Ctrl+P quick open, spaces split the search" : "off - stock Files panel and filter";
+      },
+      writeArg: function (next) { return next; },
+      toast: function (next) {
+        return next
+          ? "Files quick open on - press Ctrl+P on the Code tab"
+          : "Files quick open off - the Files panel is stock again";
+      },
+      errorPrefix: "Could not change Files quick open: "
+    });
+  }
+
   // --- motion: the pulsing Cowork glow ------------------------------------
   // Ours and it applies live, so it is a row in Community Features rather than a
   // nav entry of its own.
@@ -1290,6 +1324,7 @@
   var FEATURE_ROWS = [
     renderDiffViewsRow,
     renderPanelTabsRow,
+    renderFilesQuickOpenRow,
     renderGlowRow,
     renderThemePickerRow
   ];

--- a/js/files_quick_open_bridge.js
+++ b/js/files_quick_open_bridge.js
@@ -1,0 +1,24 @@
+/*
+ * files_quick_open_bridge.js - the ONLY channel the claude.ai page can use to
+ * reach the Files quick open backend. Injected into .vite/build/mainView.js by
+ * patches/community/add_feature_files_quick_open_bridge.nim.
+ *
+ * SECURITY: the page behind this preload is REMOTE code. Fixed wrappers around
+ * fixed channel names - no generic invoke passthrough. Argument shapes are
+ * re-validated on the main side (js/files_quick_open_main.js).
+ */
+"use strict";
+(function () {
+  // __cdb_files_quick_open_bridge
+  var electron = require("electron");
+  var contextBridge = electron.contextBridge;
+  var ipcRenderer = electron.ipcRenderer;
+  if (!contextBridge || !ipcRenderer) return;
+
+  contextBridge.exposeInMainWorld("cdbQuickOpen", {
+    version: 1,
+    state: function () { return ipcRenderer.invoke("cdb-qopen:state"); },
+    prefRead: function () { return ipcRenderer.invoke("cdb-qopen:pref-read"); },
+    prefSet: function (enabled) { return ipcRenderer.invoke("cdb-qopen:pref-set", enabled === true); }
+  });
+})();

--- a/js/files_quick_open_main.js
+++ b/js/files_quick_open_main.js
@@ -1,0 +1,276 @@
+/*
+ * files_quick_open_main.js - main-process half of the Files quick open feature.
+ *
+ * Owns the opt-in pref and injects the page script on dom-ready. The page half
+ * (js/files_quick_open_page.js, embedded by
+ * patches/community/add_feature_files_quick_open.nim) polls state() and arms or disarms its
+ * Ctrl+P hotkey from what it reports, which is what makes the switch live with no
+ * restart.
+ *
+ * SECURITY: the caller is remote claude.ai code. Every handler validates the
+ * sender's ORIGIN (not a substring test of the URL - see okSender below) and
+ * takes only a boolean; nothing page-supplied reaches the filesystem.
+ */
+;/*__CDB_FILES_QUICK_OPEN__*/(function () {
+  "use strict";
+  if (typeof process === "undefined" || process.platform !== "linux") return;
+  if (globalThis.__cdbFilesQuickOpenMain) return;
+  globalThis.__cdbFilesQuickOpenMain = true;
+
+  var _electron = require("electron");
+  var _app = _electron.app;
+  var _ipc = _electron.ipcMain;
+  var _fs = require("fs");
+  var _path = require("path");
+  var _URL = require("url").URL;
+
+  var PAGE_SRC = "__CDB_QOPEN_PAGE_SRC__";
+  var PREF_KEY = "filesQuickOpen";
+  var PREF_DEFAULT = false;
+  var JSONC_NAME = "claude-desktop-extra.jsonc";
+  var JSON_NAME = "claude-desktop-extra.json";
+
+  function log(m) { (globalThis.__cdbDiag || console.log)("[files-quick-open] " + m); }
+
+  function userDir() {
+    try { return _app.getPath("userData"); } catch (e) { return null; }
+  }
+  // Same as every other config consumer (js/diff_views_main.js, extra_settings_main.js,
+  // growthbook_overrides.js, patches/add_feature_cowork_glow.nim): the one-time
+  // claude-desktop-bin.* -> claude-desktop-extra.* rename migration is installed by
+  // the custom-themes patch and same-anchor prefix injections stack in reverse, so
+  // it may not have run yet when we get here. Nudging it before every path
+  // resolution is defence-in-depth against a write landing before the migration
+  // runs and orphaning a user's legacy config.
+  function pathFor(name) {
+    try { (globalThis.__cdbCfgMigrate || function () {})(); } catch (e) {}
+    var d = userDir();
+    return d ? _path.join(d, name) : null;
+  }
+
+  // Comment/trailing-comma stripper for the .jsonc/.json config files, shared
+  // in spirit with the diff-views pref reader (js/diff_views_main.js). A naive
+  // "strip from // to end of line unless preceded by :" heuristic corrupts any
+  // string VALUE that happens to contain "//" without a preceding colon (a
+  // path fragment, not just a URL) - e.g. {"note":"see a//b for details"}
+  // truncates mid-string and the file fails to parse. Matching whole quoted
+  // strings FIRST and passing them through untouched is the only way to strip
+  // comments without risking string contents, whatever they contain.
+  function stripComments(s) {
+    return String(s)
+      .replace(/("(?:[^"\\]|\\.)*")|\/\/[^\n]*|\/\*[\s\S]*?\*\//g, function (m, q) { return q ? q : ""; })
+      .replace(/,(\s*[}\]])/g, "$1");
+  }
+  // LENIENT reader for the read-only paths (pref lookup / lock detection): any
+  // problem - missing file, unparseable JSON, wrong shape - is reported the
+  // same as "no pref set here" and falls through to the next source. This is
+  // safe here because nothing is written back. writePref (below) does NOT use
+  // this function for its own existing-file read: a write must distinguish
+  // "absent" from "present but broken" instead of silently treating both as
+  // empty, or a broken file gets overwritten and every other key in it is lost.
+  function readFileJson(p) {
+    try {
+      if (!p || !_fs.existsSync(p)) return null;
+      var stripped = stripComments(_fs.readFileSync(p, "utf8"));
+      var v = stripped.trim() ? JSON.parse(stripped) : {};
+      return (v && typeof v === "object" && !Array.isArray(v)) ? v : null;
+    } catch (e) { return null; }
+  }
+
+  // The .jsonc is the HUMAN-OWNED file and wins the startup merge, so a value
+  // found there is reported as locked and pref-set refuses to fight it instead
+  // of writing a .json the merge would then ignore.
+  function readPrefFromDisk() {
+    var jsonc = readFileJson(pathFor(JSONC_NAME));
+    if (jsonc && typeof jsonc[PREF_KEY] === "boolean") {
+      return { value: jsonc[PREF_KEY], source: "jsonc-locked" };
+    }
+    var json = readFileJson(pathFor(JSON_NAME));
+    if (json && typeof json[PREF_KEY] === "boolean") {
+      return { value: json[PREF_KEY], source: "json" };
+    }
+    return { value: PREF_DEFAULT, source: "default" };
+  }
+
+  // Writes ONLY the .json (the .jsonc is never created or rewritten here), tmp +
+  // rename so a crash cannot leave half a file, and every other key survives.
+  //
+  // Unlike readFileJson above, an existing-but-broken file is NOT silently
+  // treated as empty here: that would make pref-set report success while
+  // quietly discarding every other extra's settings the moment a user's
+  // hand-edited file has a stray comma or an unbalanced brace. ENOENT (file
+  // genuinely absent) is the only case that proceeds with an empty object;
+  // every other read/parse/shape failure refuses and writes nothing.
+  function writePref(value) {
+    var p = pathFor(JSON_NAME);
+    if (!p) return { ok: false, error: "no userData path" };
+    var raw = null;
+    try { raw = _fs.readFileSync(p, "utf8"); }
+    catch (e) {
+      if (e.code !== "ENOENT") return { ok: false, error: "cannot read " + p + ": " + ((e && e.message) || String(e)) };
+    }
+    var cfg = {};
+    if (raw !== null) {
+      var stripped = stripComments(raw);
+      try { cfg = stripped.trim() ? JSON.parse(stripped) : {}; }
+      catch (e2) {
+        return { ok: false, error: p + " is not valid JSON (" + e2.message +
+          ") - fix or remove it first; nothing was written" };
+      }
+      if (!cfg || typeof cfg !== "object" || Array.isArray(cfg)) {
+        return { ok: false, error: p + " must contain a JSON object; nothing was written" };
+      }
+      if (stripped !== raw) {
+        // Rewriting as plain JSON drops comments - keep the original once.
+        try { _fs.writeFileSync(p + ".cdb-bak", raw, { flag: "wx" }); } catch (e3) {}
+      }
+    }
+    // The default is FALSE, so "off" is the ABSENCE of the key: a fresh install
+    // and one that switched the feature back off look the same on disk, and only
+    // an explicit opt-in ever writes anything.
+    if (value === PREF_DEFAULT) delete cfg[PREF_KEY];
+    else cfg[PREF_KEY] = value;
+    var tmp = p + ".cdb-tmp";
+    try {
+      _fs.writeFileSync(tmp, JSON.stringify(cfg, null, 2) + "\n", "utf8");
+      _fs.renameSync(tmp, p);
+    } catch (e4) {
+      try { _fs.unlinkSync(tmp); } catch (e5) {}
+      return { ok: false, error: "cannot write " + p + ": " + ((e4 && e4.message) || String(e4)) };
+    }
+    return { ok: true, path: p };
+  }
+
+  // ---- worker gate --------------------------------------------------------------
+  // The file-index utility process (.vite/build/file-index-worker/) decides
+  // whether to split queries on whitespace from process.env.CDB_FILES_QUICK_OPEN
+  // (see js/files_quick_open_worker.js).
+  //
+  // Setting it here is only half the gate: Electron's utilityProcess.fork() with
+  // no `env` option hands the child the browser process's INITIAL environment,
+  // NOT the live process.env - so a value written at runtime never reached the
+  // worker (measured 1.40609.0, 2026-08-29: the key was in main's /proc environ
+  // and in none of the utility processes). The other half is sub-patch B of
+  // patches/community/add_feature_files_quick_open.nim, which makes the generic
+  // worker host fork with `env: Object.assign({}, process.env)`. With both in
+  // place, mirroring the pref here reaches every worker forked from now on. A
+  // worker that is already running keeps the value it was born with until
+  // upstream restarts it (idle exit / cwd change) or the app restarts - the
+  // settings row says so.
+  function mirrorEnv(on) {
+    try { process.env.CDB_FILES_QUICK_OPEN = on ? "1" : "0"; } catch (e) {}
+  }
+  // What the worker gate currently reads, reported back over IPC so the switch's
+  // effect on the index is observable without a /proc dig: "1", "0", or null when
+  // the variable is unset or holds something we never wrote.
+  function envGate() {
+    try {
+      var v = process.env.CDB_FILES_QUICK_OPEN;
+      return (v === "1" || v === "0") ? v : null;
+    } catch (e) { return null; }
+  }
+  mirrorEnv(readPrefFromDisk().value === true);
+
+  // Exact-origin allowlist, same posture as the diff-views and cowork-glow
+  // sender checks: comparing parsed origins instead of testing whether the raw
+  // URL STRING contains "claude.ai"/"claude.com" anywhere. A substring test
+  // would also pass a lookalike host such as "https://evil.example/?next=
+  // claude.ai" or "https://claude.ai.evil.example" - both contain the
+  // substring, neither is our origin.
+  var ALLOWED_ORIGINS = [
+    "https://claude.ai",
+    "https://preview.claude.ai",
+    "https://claude.com",
+    "https://preview.claude.com"
+  ];
+  function originAllowed(rawUrl) {
+    var origin;
+    try { origin = new _URL(String(rawUrl)).origin; } catch (e) { return false; }
+    for (var i = 0; i < ALLOWED_ORIGINS.length; i++) {
+      if (origin === ALLOWED_ORIGINS[i]) return true;
+    }
+    return false;
+  }
+  // FAILS CLOSED: wc.isDestroyed() is called unguarded, same as the diff-views
+  // precedent - a sender object missing the method throws, the catch below
+  // turns that into "not ok", not "assume fine". Do not soften this to a
+  // typeof-guard that treats a missing method as "not destroyed".
+  function okSender(ev) {
+    try {
+      var wc = ev && ev.sender;
+      if (!wc || wc.isDestroyed()) return false;
+      if (!originAllowed(wc.getURL() || "")) return false;
+      var frame = ev.senderFrame;
+      if (frame && frame.parent) return false;
+      return true;
+    } catch (e) { return false; }
+  }
+
+  _ipc.handle("cdb-qopen:state", function (ev) {
+    if (!okSender(ev)) return { ok: false, error: "rejected: unrecognized sender" };
+    var disk = readPrefFromDisk();
+    return { ok: true, enabled: disk.value === true, source: disk.source, envGate: envGate() };
+  });
+
+  _ipc.handle("cdb-qopen:pref-read", function (ev) {
+    if (!okSender(ev)) return { ok: false, error: "rejected: unrecognized sender" };
+    var disk = readPrefFromDisk();
+    return { ok: true, enabled: disk.value === true,
+      lockedByJsonc: disk.source === "jsonc-locked", source: disk.source, envGate: envGate() };
+  });
+
+  _ipc.handle("cdb-qopen:pref-set", function (ev, enabled) {
+    if (!okSender(ev)) return { ok: false, error: "rejected: unrecognized sender" };
+    if (typeof enabled !== "boolean") return { ok: false, error: "enabled must be a boolean" };
+    var disk = readPrefFromDisk();
+    if (disk.source === "jsonc-locked") {
+      return { ok: false, error: PREF_KEY + " is set in " + JSONC_NAME +
+        " - edit that file to change it" };
+    }
+    var w = writePref(enabled);
+    if (!w.ok) return w;
+    mirrorEnv(enabled);
+    return { ok: true, enabled: enabled, path: w.path };
+  });
+
+  // ---- page injection ---------------------------------------------------------
+  // Injected in BOTH pref states: the page polls state() itself and arms or
+  // disarms its Ctrl+P hotkey from what it reports (slowly, for the life of
+  // the page), which makes the settings toggle apply live with no restart. With
+  // no bridge present the page degrades silently (no throw, no warn spam,
+  // feature off) - this handler is what makes it live at all.
+  //
+  // The URL test here only decides whether to bother running executeJavaScript
+  // on this webContents, it is NOT a security boundary (the page script itself
+  // does nothing sensitive - it only defines globals and polls state(), which
+  // re-validates the sender origin strictly, above). It is looser than
+  // ALLOWED_ORIGINS on purpose: any claude.ai/claude.com subdomain gets the
+  // injection, so an upstream move to another subdomain does not kill the modal.
+  function injectHost(rawUrl) {
+    var host;
+    try { host = new _URL(String(rawUrl)).hostname; } catch (e) { return false; }
+    return host === "claude.ai" || host.endsWith(".claude.ai") ||
+      host === "claude.com" || host.endsWith(".claude.com");
+  }
+  _app.on("web-contents-created", function (_ev, wc) {
+    wc.on("dom-ready", function () {
+      try {
+        var url = (wc.getURL && wc.getURL()) || "";
+        if (injectHost(url)) {
+          wc.executeJavaScript(PAGE_SRC).catch(function () {});
+        }
+      } catch (e) {}
+    });
+  });
+
+  // Our IIFE runs before __cdbDiag exists (same-anchor injections stack, and
+  // console.log is discarded by the official build), so a synchronous log
+  // here would be silently lost. Deferring one tick lets all top-level bundle
+  // code run first, by which point __cdbDiag is defined.
+  setTimeout(function () {
+    var disk = readPrefFromDisk();
+    log("installed (main); pref " + PREF_KEY + "=" + disk.value + " (source: " + disk.source +
+      "; worker gate CDB_FILES_QUICK_OPEN=" + envGate() + ")" +
+      (disk.value ? "" : " - opt-in feature is off: Ctrl+P inert, index untouched"));
+  }, 0);
+})();

--- a/js/files_quick_open_page.js
+++ b/js/files_quick_open_page.js
@@ -1,0 +1,658 @@
+/*
+ * files_quick_open_page.js - the renderer half of the Files quick open feature.
+ * Injected into the claude.ai page (main world) on dom-ready by
+ * js/files_quick_open_main.js, which patches/community/add_feature_files_quick_open.nim
+ * embeds. Talks to main ONLY through window.cdbQuickOpen (the preload bridge,
+ * js/files_quick_open_bridge.js) and to upstream ONLY through APIs upstream itself
+ * exposes to this page: window["claude.web"].Resources.fetchMentionOptions and the
+ * Files tree's own React onPreview handler.
+ *
+ * WHAT IT DOES: Ctrl+P on the Code tab opens a VS Code-style quick-open box over
+ * the Files tile. Typing queries upstream's fuzzy file index (the same one behind
+ * the tile's own filter and the composer's @ picker); ArrowUp/Down + Enter or a
+ * mouse click opens the pick as a file tab INSIDE the Files tile by calling the
+ * tree's onPreview(absPath, line) - exactly what a click on a tree row does.
+ * "path:42" opens at a line. An empty query lists recently opened files (MRU,
+ * per tile root, in localStorage) - VS Code's "recently opened" section. With no
+ * derivable tile root the MRU is disabled outright (see the MRU section).
+ *
+ * ANCHORS (remote claude.ai markup, measured 2026-08-29 on 1.37937.3; inventoried
+ * in baseline/FILES_QUICK_OPEN_ANCHORS.md). Every one degrades to a no-op plus a
+ * single console.warn per key - never a throw:
+ *   PANE_SEL    the Files pane root
+ *   FILTER_SEL  its filter box (only used as a fiber entry point of last resort)
+ *   TREE_SEL / ROW_SEL   the tree and its (virtualized) rows
+ *   SHOW_TREE_SEL  the toolbar button that brings a hidden tree back
+ *   MENU_SEEDS -> SESSION_MENU_SEL  the session ⋮ (climbed to from a toolbar
+ *                        button), and its "Files" entry - the only way to create
+ *                        a Files pane when none is open
+ *   fiber ancestor with memoizedProps.onPreview: function (path, line, findQuery)
+ *                        (its memoizedProps.root, when a string, IS the tile root)
+ *   row fiber ancestor with memoizedProps.entry {absPath, relativePath} -> tile root
+ *                        (absent -> root null, MRU disabled, warning no-entry)
+ *
+ * THE TREE CAN BE HIDDEN. The Files pane showing an open file with its tree
+ * collapsed has no tree, no rows, no filter box and NOTHING exposing onPreview
+ * anywhere in its fibers (measured live 2026-08-29 on 1.40609.0). Upstream's own
+ * "Show file tree" button restores all of it, so Ctrl+P clicks that button and
+ * waits before harvesting. The modal still mounts synchronously - only the
+ * harvest waits - and the tree is left visible afterwards.
+ *
+ * THE HARVEST IS THE WAIT CONDITION, not the DOM. The component that owns
+ * onPreview is found by DESCENDING from the pane root (depth 10, ~55 fibers on
+ * 1.40609.0) - the only strategy that works while the tree has rendered no rows,
+ * which is exactly how a freshly opened pane starts. Walking UP still works from
+ * a [role=treeitem] ROW and is kept as the fallback; up from the tree or the
+ * filter box returns null, so "a tree exists" is not "we can open a file". The
+ * page polls findPreviewProps() itself and keeps polling while it returns null,
+ * up to TREE_WAIT_MS (PANE_WAIT_MS when a pane still has to be created).
+ *
+ * THE PANE CAN BE CLOSED ENTIRELY. Then nothing in the page exposes onPreview and
+ * there is no "Show file tree" button either - the only way in is upstream's own
+ * session menu (⋮ -> Files, its own Ctrl+F). Ctrl+P drives that menu: the user
+ * asked to open a file, so opening the panel they would have opened by hand is
+ * the point. The entry is a TOGGLE, so it is only ever pressed when there is no
+ * pane - pressing it with one open would close the pane we need. Upstream's own
+ * accelerator cannot be used instead: a synthetic Ctrl+F is untrusted and does
+ * nothing (measured 1.40609.0). No menu is ever left hanging over the app.
+ */
+;(function () {
+  "use strict";
+  if (window.__cdbQuickOpenPage) return;
+
+  var STATE_POLL_MS = (typeof window.__cdbQoTestPollMs === "number") ? window.__cdbQoTestPollMs : 5000;
+  var MAX_RESULTS = 15;
+  var MAX_MRU = 15;
+  var DEBOUNCE_MS = 120;
+  var MAX_HOPS = 60;
+  // Descent bounds: the handler sits at depth 10 after ~55 fibers on 1.40609.0.
+  var MAX_DESCEND_DEPTH = 40;
+  var MAX_FIBER_VISITS = 4000;
+  var PANE_SEL = '[data-pane-root][data-perf-screen="file"]';
+  var FILTER_SEL = 'input[aria-label="Filter files"]';
+  var TREE_SEL = '[role="tree"]';
+  var ROW_SEL = '[role="treeitem"]';
+  var SHOW_TREE_SEL = 'button[aria-label="Show file tree"]';
+  // No pane at all: upstream's session ⋮ menu carries a Files entry (labelled
+  // "Files" + its own Ctrl+F shortcut, rendered without a separator). The ⋮ is
+  // NOT a sibling of the Terminal/Diff/Browser toolbar buttons - measured
+  // 1.40609.0, it sits 2 parents above one of them, in the single ancestor that
+  // holds exactly one "More options for …" button. That climb is the anchor: a
+  // bare document query would hit any of the ~76 per-session ⋮ in the sidebar.
+  var MENU_SEEDS = ['button[aria-label^="Diff ("]', 'button[aria-label="Terminal"]',
+    'button[aria-label="Browser"]'];
+  var SESSION_MENU_SEL = 'button[aria-label^="More options for "]';
+  var MENU_ITEM_SEL = '[role="menuitem"],[role="menuitemcheckbox"]';
+  // The rendered label runs the shortcut straight onto the word ("FilesCtrlF" on
+  // 1.40609.0 - no separator, so \b would not match), hence a bare prefix test.
+  var FILES_ITEM_RE = /^files/i;
+  var MENU_CLIMB_HOPS = 6;
+  var TREE_POLL_MS = 50;
+  // The budget for the whole harvest, click included. A cold render was measured
+  // at ~700 ms on 1.40609.0; 1500 was tight and the failure mode is silent.
+  var TREE_WAIT_MS = 3000;
+  // Opening a pane from scratch adds two upstream stages before the harvest can
+  // even start: the menu renders, then the pane mounts (~900 ms end to end live).
+  var MENU_WAIT_MS = 1500;
+  var MENU_TIDY_MS = 400;
+  var PANE_WAIT_MS = 5000;
+  var ROOT_ID = "cdb-qopen";
+  var STYLE_ID = "cdb-qopen-style";
+  var MRU_PREFIX = "cdb-qopen-mru:";
+  var HINT_NO_PANE = "Open the Files panel first (Session actions → Files)";
+  var HINT_NO_HANDLER = "Cannot open files: the Files panel changed (onPreview anchor missing)";
+  var HINT_OTHER_ROOT = "Results are for another session's folder - click into this session first";
+  var HINT_EMPTY = "Type to search files in this session's folder";
+  var HINT_NO_MATCH = "No matching files";
+  var HINT_MRU = "Recently opened";
+  var HINT_SHOWING_TREE = "Showing the file tree…";
+  var HINT_OPENING_PANE = "Opening the Files panel…";
+  var HINT_KEYS = "↑↓ to select · Enter to open · :<line> to jump";
+
+  var warned = {};
+  function warnOnce(key, msg) {
+    if (warned[key]) return;
+    warned[key] = true;
+    try { console.warn("[cdb-qopen] " + key + ": " + msg); } catch (e) {}
+  }
+
+  // ---- pref -------------------------------------------------------------------
+  var enabled = false;
+  function setEnabled(on) {
+    if (on === enabled) return;
+    enabled = on;
+    if (!on) close();
+  }
+  function pollPref() {
+    var b = window.cdbQuickOpen, p;
+    if (!b || typeof b.state !== "function") { setEnabled(false); return; }
+    try { p = b.state(); } catch (e) { warnOnce("pref-threw", "cdbQuickOpen.state() threw: " + ((e && e.message) || e)); return; }
+    if (!p || typeof p.then !== "function") { warnOnce("pref-shape", "cdbQuickOpen.state() did not return a promise"); return; }
+    p.then(function (r) { setEnabled(!!(r && r.ok === true && r.enabled === true)); }, function () {});
+  }
+
+  // ---- anchors ----------------------------------------------------------------
+  function fiberOf(node) {
+    if (!node) return null;
+    for (var k in node) if (k.indexOf("__reactFiber$") === 0) return node[k];
+    return null;
+  }
+  function filesPane() { return document.querySelector(PANE_SEL); }
+  // A folder path with exactly one trailing slash, or null. The tile root is
+  // concatenated with a relative path, so the slash has to be certain.
+  function normRoot(r) {
+    if (typeof r !== "string" || !r) return null;
+    return r.charAt(r.length - 1) === "/" ? r : r + "/";
+  }
+  // The tree's open handler, plus the root it was rendered for. A ROW is the only
+  // start that was ever measured to work (hop ~12, the list component just above
+  // the rows); the walk up from the tree and from the filter box returned null on
+  // 1.40609.0. The tree and the filter box are kept as fallback starts - harmless,
+  // and cheap insurance if upstream moves the handler down - but the CALLER must
+  // never treat "a tree exists" as "the harvest is done" (see awaitProbe).
+  // The owning component carries the folder the tile shows as a string `root`
+  // prop (measured alongside sessionId/scope/reveal), which is more direct than
+  // deriving it from a row.
+  // Returns { onPreview: function, root: string|null } or null.
+  // DESCEND from the pane root. This is the primary strategy because it is the
+  // only one that works when the tree has rendered NO rows - measured 1.40609.0
+  // on a pane opened from scratch: the tree element is there, rows are still
+  // empty, and walking UP from the tree or the filter box finds nothing, because
+  // the component that owns onPreview is not their ancestor. Descending finds it
+  // at depth 10 after ~55 fibers, and it carries the tile's `root` prop directly.
+  function descendPreviewProps(pane) {
+    var root = fiberOf(pane);
+    if (!root) return null;
+    var queue = [[root, 0]], visits = 0;
+    while (queue.length && visits < MAX_FIBER_VISITS) {
+      var entry = queue.shift(), f = entry[0], depth = entry[1];
+      if (!f || depth > MAX_DESCEND_DEPTH) continue;
+      visits++;
+      var p = f.memoizedProps;
+      if (p && typeof p === "object" && typeof p.onPreview === "function")
+        return { onPreview: p.onPreview, root: normRoot(p.root) };
+      if (f.child) queue.push([f.child, depth + 1]);
+      if (f.sibling) queue.push([f.sibling, depth]);
+    }
+    return null;
+  }
+  function findPreviewProps(pane) {
+    var down = descendPreviewProps(pane);
+    if (down) return down;
+    var starts = [pane.querySelector(ROW_SEL), pane.querySelector(TREE_SEL), pane.querySelector(FILTER_SEL)];
+    for (var s = 0; s < starts.length; s++) {
+      var f = fiberOf(starts[s]), i = 0;
+      while (f && i++ < MAX_HOPS) {
+        var p = f.memoizedProps;
+        if (p && typeof p.onPreview === "function") return { onPreview: p.onPreview, root: normRoot(p.root) };
+        f = f.return;
+      }
+    }
+    return null;
+  }
+  // absPath minus relativePath of any rendered row = the folder the tile shows.
+  function tileRoot(pane) {
+    var rows = pane.querySelectorAll(ROW_SEL);
+    for (var r = 0; r < rows.length; r++) {
+      var f = fiberOf(rows[r]), i = 0;
+      while (f && i++ < MAX_HOPS) {
+        var p = f.memoizedProps, e = p && p.entry;
+        if (e && typeof e.absPath === "string" && typeof e.relativePath === "string" &&
+            e.absPath.length > e.relativePath.length &&
+            e.absPath.slice(e.absPath.length - e.relativePath.length) === e.relativePath) {
+          return e.absPath.slice(0, e.absPath.length - e.relativePath.length);
+        }
+        f = f.return;
+      }
+    }
+    // Rows are rendered but none of them carries a usable entry -> the anchor
+    // moved. Zero rows is NOT a warning: the pane is simply empty or filtered
+    // down to nothing, and there is nothing to derive a root from either way.
+    if (rows.length)
+      warnOnce("no-entry", "no rendered row exposes entry.absPath/relativePath - tile root unknown, MRU disabled");
+    return null;
+  }
+  // ONE harvest attempt over the pane's REMOTE fibers. Returns
+  //   { onPreview, root } - the handler is reachable now
+  //   null              - it is not there (yet); the caller may retry
+  //   false             - a memoizedProps accessor THREW. That is not a "not
+  //                       yet": remote code we do not control blew up, so the
+  //                       caller stops retrying and reports the anchor as gone.
+  // The fiber's own `root` prop wins; the row-derived root is the fallback (and
+  // only then can the no-entry warning fire, since only then is it needed).
+  function probe(pane) {
+    if (!pane) return null;
+    try {
+      var hit = findPreviewProps(pane);
+      if (!hit) return null;
+      return { onPreview: hit.onPreview, root: hit.root || tileRoot(pane) };
+    } catch (e) {
+      warnOnce("open-threw", "harvesting the Files pane threw: " + ((e && e.message) || e));
+      return false;
+    }
+  }
+  // Writes a probe result into ctx. `final` = no further attempt is coming, so a
+  // miss is now worth a warning (a miss on the FIRST attempt is routine: the pane
+  // is still rendering).
+  function settle(pane, hit, final) {
+    if (!ctx) return;
+    ctx.onPreview = hit ? hit.onPreview : null;
+    ctx.root = (hit && hit.root) || null;
+    if (final && pane && !ctx.onPreview)
+      warnOnce("no-onpreview", "no fiber ancestor with an onPreview function under the Files pane");
+  }
+  // The pane can be showing an open file with the tree collapsed: no tree, no
+  // rows, no filter box - and nothing anywhere in its fibers exposing onPreview
+  // (measured 1.40609.0). Everything we need comes back when upstream's own
+  // toolbar button is clicked, so click it rather than giving up.
+  function treeHidden(pane) { return !pane.querySelector(TREE_SEL) && !pane.querySelector(ROW_SEL); }
+  function showTreeButton(pane) { return pane ? pane.querySelector(SHOW_TREE_SEL) : null; }
+  // Runs upstream's own toggle. false = the click threw, so nothing is coming and
+  // there is nothing to wait for. The tree is left visible either way: it is
+  // upstream's own toggle and the user asked for a file.
+  function clickShowTree(btn) {
+    try { btn.click(); return true; }
+    catch (e) {
+      warnOnce("show-tree-threw", "clicking the \"Show file tree\" button threw: " + ((e && e.message) || e));
+      return false;
+    }
+  }
+  // The session ⋮ button, found by climbing from a toolbar button it shares an
+  // ancestor with (see MENU_SEEDS). More than one match means the climb left the
+  // header and reached the sidebar's per-session menus, so it refuses instead of
+  // opening a menu on some unrelated session.
+  function sessionMenuButton() {
+    for (var s = 0; s < MENU_SEEDS.length; s++) {
+      var seed = document.querySelector(MENU_SEEDS[s]);
+      var node = seed, hops = 0;
+      while (node && hops++ < MENU_CLIMB_HOPS) {
+        var found = node.querySelectorAll(SESSION_MENU_SEL);
+        if (found.length === 1) return found[0];
+        if (found.length > 1) break;             // ambiguous - try the next seed
+        node = node.parentElement;
+      }
+    }
+    return null;
+  }
+  // Upstream's menu renders after its own click, so the entry is polled for. The
+  // label carries the shortcut ("Files" + Ctrl+F), hence a prefix match.
+  function clickFilesMenuItem() {
+    var items = document.querySelectorAll(MENU_ITEM_SEL);
+    for (var i = 0; i < items.length; i++) {
+      var text = (items[i].textContent || "").replace(/[^\x20-\x7e]/g, "").trim();
+      if (!FILES_ITEM_RE.test(text)) continue;
+      try { items[i].click(); return true; }
+      catch (e) {
+        warnOnce("files-item-threw", "clicking the session menu's Files entry threw: " + ((e && e.message) || e));
+        return false;
+      }
+    }
+    return false;
+  }
+  // Leaves no menu open over the app when we could not use it.
+  function dismissMenu() {
+    try { document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true })); } catch (e) {}
+  }
+  // Drives ⋮ → Files and calls done(ok) exactly once. ok=false means no pane is
+  // coming, so the caller stops rather than waiting out the harvest budget.
+  function openFilesPane(opener, done) {
+    var finished = false, waited = 0;
+    function finish(ok) {
+      if (finished) return;
+      finished = true;
+      // Upstream closes its own menu when an entry is chosen; if some menu is
+      // still up shortly after, it is ours to clear - never leave one hanging
+      // over the app.
+      window.setTimeout(function () { if (document.querySelector(MENU_ITEM_SEL)) dismissMenu(); }, MENU_TIDY_MS);
+      done(ok);
+    }
+    // Start from a known state: a menu already open (the user's, or one left by a
+    // previous attempt) would make the click below TOGGLE it shut, and the entry
+    // we then find would belong to a menu nobody asked for.
+    if (document.querySelector(MENU_ITEM_SEL)) dismissMenu();
+    try { opener.click(); }
+    catch (e) {
+      warnOnce("session-menu-threw", "clicking the session menu button threw: " + ((e && e.message) || e));
+      finish(false);
+      return;
+    }
+    var timer = window.setInterval(function () {
+      waited += TREE_POLL_MS;
+      if (!isOpen()) { clearInterval(timer); dismissMenu(); finish(false); return; }
+      if (clickFilesMenuItem()) { clearInterval(timer); finish(true); return; }
+      if (waited >= MENU_WAIT_MS) {
+        clearInterval(timer);
+        warnOnce("no-files-menu-item", "the session menu has no Files entry within " + MENU_WAIT_MS + "ms");
+        dismissMenu();
+        finish(false);
+      }
+    }, TREE_POLL_MS);
+  }
+  // Polls the HARVEST - not the DOM - until it yields a handler, and calls
+  // done(hit|null, pane) exactly once. Waiting on `!treeHidden(pane)` instead was
+  // the 1.40609.0 open-path bug: the tree element commits before its rows, the
+  // first tick saw a tree, harvested nothing and never tried again.
+  //
+  // `pane` may be null: the pane is then re-queried every tick, which is what the
+  // ⋮ → Files path needs (it is still mounting). A pane that arrives with its tree
+  // collapsed gets upstream's own toggle pressed once, so both stages are covered
+  // by this one loop.
+  function awaitProbe(pane, done) {
+    var finished = false, waited = 0, clickedShowTree = false;
+    var budget = pane ? TREE_WAIT_MS : PANE_WAIT_MS;
+    function finish(hit, p) { if (!finished) { finished = true; done(hit, p); } }
+    var timer = window.setInterval(function () {
+      waited += TREE_POLL_MS;
+      if (!isOpen()) { clearInterval(timer); finish(null, pane); return; }   // the caller's own guard drops it
+      var p = pane || filesPane();
+      if (p) {
+        if (!clickedShowTree && treeHidden(p)) {
+          var btn = showTreeButton(p);
+          if (btn) { clickedShowTree = true; clickShowTree(btn); }
+        }
+        var hit = probe(p);
+        if (hit) { clearInterval(timer); finish(hit, p); return; }
+        if (hit === false) { clearInterval(timer); finish(null, p); return; }   // threw: final, already warned
+      }
+      if (waited >= budget) {
+        clearInterval(timer);
+        warnOnce("harvest-timeout", "no onPreview handler appeared under the Files pane within " +
+          budget + "ms");
+        finish(null, p);
+      }
+    }, TREE_POLL_MS);
+  }
+  function resources() {
+    var cw = window["claude.web"];
+    return (cw && cw.Resources && typeof cw.Resources.fetchMentionOptions === "function") ? cw.Resources : null;
+  }
+
+  // ---- query + search ---------------------------------------------------------
+  // "text:42" -> { text: "text", line: 42 }. Only a TRAILING :<digits> is a line.
+  function parseQuery(raw) {
+    var m = /^(.*?)(?::(\d+))?\s*$/.exec(String(raw || ""));
+    return { text: (m ? m[1] : "").trim(), line: (m && m[2]) ? parseInt(m[2], 10) : undefined };
+  }
+  function search(text, cb) {
+    var api = resources();
+    if (!api) { cb(null, "bridge"); return; }
+    var p;
+    try { p = api.fetchMentionOptions(text, "files"); } catch (e) { cb(null, "threw"); return; }
+    if (!p || typeof p.then !== "function") { cb(null, "shape"); return; }
+    p.then(function (list) { cb(Array.isArray(list) ? list : [], null); }, function () { cb(null, "rejected"); });
+  }
+  // Upstream's mention option -> { rel, abs, positions }; directories skipped.
+  function toItems(list) {
+    var out = [];
+    for (var i = 0; i < list.length && out.length < MAX_RESULTS; i++) {
+      var e = list[i];
+      if (!e || typeof e.id !== "string" || e.id.indexOf("file-") !== 0) continue;
+      var meta = {};
+      if (typeof e.metadata === "string") { try { meta = JSON.parse(e.metadata) || {}; } catch (x) { meta = {}; } }
+      else if (e.metadata && typeof e.metadata === "object") meta = e.metadata;
+      if (meta.isDirectory === true) continue;
+      var rel = typeof meta.path === "string" ? meta.path : String(e.label || "");
+      if (!rel) continue;
+      out.push({ rel: rel, abs: e.id.slice(5), positions: Array.isArray(meta.positions) ? meta.positions : [] });
+    }
+    return out;
+  }
+
+  // ---- MRU --------------------------------------------------------------------
+  // The MRU is keyed by the tile root and stores RELATIVE paths, so it is only
+  // meaningful with a known root. With no root (empty pane, or the entry anchor
+  // moved) the whole MRU is disabled rather than falling back to a root-less
+  // key: reading it would render rows whose absolute path is just the relative
+  // one (upstream's onPreview does e.startsWith(...) and would throw or open
+  // nothing), and writing it would hide the real MRU under a second key.
+  function haveRoot() { return !!(ctx && ctx.root); }
+  function mruKey() { return MRU_PREFIX + (ctx && ctx.root ? ctx.root : ""); }
+  function readMru() {
+    try { var v = JSON.parse(window.localStorage.getItem(mruKey()) || "[]"); return Array.isArray(v) ? v.filter(function (s) { return typeof s === "string"; }) : []; }
+    catch (e) { return []; }
+  }
+  function remember(rel) {
+    if (!haveRoot()) return;
+    try {
+      var list = readMru().filter(function (s) { return s !== rel; });
+      list.unshift(rel);
+      window.localStorage.setItem(mruKey(), JSON.stringify(list.slice(0, MAX_MRU)));
+    } catch (e) {}
+  }
+  function mruItems() {
+    if (!haveRoot()) return [];
+    var root = ctx.root;
+    return readMru().slice(0, MAX_RESULTS).map(function (rel) { return { rel: rel, abs: root + rel, positions: [] }; });
+  }
+
+  // ---- modal ------------------------------------------------------------------
+  var rootEl = null, inputEl = null, listEl = null, hintEl = null;
+  var items = [], sel = 0, seq = 0, debounceTimer = null, ctx = null;
+
+  function ensureStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    var st = document.createElement("style");
+    st.id = STYLE_ID;
+    st.textContent =
+      "#" + ROOT_ID + "{position:fixed;inset:0;z-index:2147483000;display:flex;align-items:flex-start;justify-content:center;padding-top:12vh;background:rgba(0,0,0,.25)}" +
+      "#" + ROOT_ID + " .cdb-qopen-box{width:min(62vw,600px);max-height:70vh;display:flex;flex-direction:column;border-radius:10px;overflow:hidden;" +
+        "background:var(--cds-surface-2,var(--cds-page-bg,#232323));color:var(--cds-text-primary,#eee);box-shadow:0 12px 40px rgba(0,0,0,.45);border:1px solid var(--cds-border-tertiary,rgba(255,255,255,.12));font:13px/1.4 var(--font-sans,system-ui,sans-serif)}" +
+      "#" + ROOT_ID + " .cdb-qopen-input{all:unset;display:block;box-sizing:border-box;width:100%;padding:10px 12px;font:14px/1.4 inherit;color:inherit;border-bottom:1px solid var(--cds-border-tertiary,rgba(255,255,255,.12))}" +
+      "#" + ROOT_ID + " .cdb-qopen-list{list-style:none;margin:0;padding:4px 0;overflow:hidden}" +
+      "#" + ROOT_ID + " .cdb-qopen-row{display:flex;gap:8px;align-items:baseline;padding:5px 12px;cursor:pointer;white-space:nowrap;overflow:hidden}" +
+      "#" + ROOT_ID + " .cdb-qopen-row[aria-selected=true]{background:var(--cds-fill-accent,#3b82f6);color:#fff}" +
+      "#" + ROOT_ID + " .cdb-qopen-name{flex:0 1 auto;overflow:hidden;text-overflow:ellipsis}" +
+      "#" + ROOT_ID + " .cdb-qopen-dir{flex:1 1 auto;min-width:0;overflow:hidden;text-overflow:ellipsis;opacity:.6;font-size:12px}" +
+      "#" + ROOT_ID + " mark{background:transparent;color:inherit;font-weight:700;text-decoration:underline}" +
+      "#" + ROOT_ID + " .cdb-qopen-hint{padding:6px 12px 8px;font-size:12px;opacity:.7;min-height:1em}";
+    (document.head || document.documentElement).appendChild(st);
+  }
+  function el(tag, cls, text) {
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (text != null) n.textContent = text;
+    return n;
+  }
+  function isOpen() { return !!rootEl && !!rootEl.parentNode; }
+
+  function open() {
+    if (!enabled) return;
+    if (isOpen()) { close(); return; }
+    var pane = filesPane();
+    ctx = { pane: pane, onPreview: null, root: null };
+    // No pane at all: upstream's ⋮ → Files makes one. The user pressed Ctrl+P to
+    // open a file, so opening the panel they would have opened by hand is the
+    // point - but only when there is genuinely no pane (the entry is a TOGGLE, so
+    // pressing it with a pane open would close the one we need).
+    var opener = pane ? null : sessionMenuButton();
+    // Hidden tree: the harvest has to wait for upstream's button to do its work.
+    // The modal itself does NOT wait - Ctrl+P stays instant.
+    var showBtn = (pane && treeHidden(pane)) ? showTreeButton(pane) : null;
+    var first = (pane && !showBtn) ? probe(pane) : null;
+    var hit = first || null;                                  // `false` (threw) -> null
+    // Retry while the pane may still be rendering (or is still being created).
+    // A throw is final, not "not yet".
+    var retry = (!!pane || !!opener) && !hit && first !== false;
+    settle(pane, hit, !retry);
+    ensureStyle();
+    rootEl = el("div"); rootEl.id = ROOT_ID; rootEl.className = "cdb-qopen-backdrop";
+    var box = el("div", "cdb-qopen-box");
+    box.setAttribute("role", "dialog");
+    box.setAttribute("aria-label", "Quick open");
+    inputEl = el("input", "cdb-qopen-input");
+    inputEl.type = "text";
+    inputEl.setAttribute("aria-label", "Quick open file");
+    inputEl.placeholder = "Type a file name  (Ctrl+P again to close)";
+    inputEl.autocomplete = "off"; inputEl.spellcheck = false;
+    listEl = el("ul", "cdb-qopen-list");
+    listEl.setAttribute("role", "listbox");
+    hintEl = el("div", "cdb-qopen-hint", "");
+    box.appendChild(inputEl); box.appendChild(listEl); box.appendChild(hintEl);
+    rootEl.appendChild(box);
+    rootEl.addEventListener("mousedown", function (ev) { if (ev.target === rootEl) close(); });
+    box.addEventListener("mousedown", function (ev) { if (ev.target !== inputEl) ev.preventDefault(); }); // keep focus in the input
+    inputEl.addEventListener("input", function () {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(run, DEBOUNCE_MS);
+    });
+    inputEl.addEventListener("keydown", onInputKey);
+    document.body.appendChild(rootEl);
+    if (!pane) hint(opener ? HINT_OPENING_PANE : HINT_NO_PANE);
+    else if (showBtn) hint(HINT_SHOWING_TREE);
+    // A retry with the tree already visible keeps the honest hint meanwhile: the
+    // handler is missing RIGHT NOW. It is cleared the moment the retry lands.
+    else if (!ctx.onPreview) hint(HINT_NO_HANDLER);
+    inputEl.focus();
+    run();                       // results render regardless of the harvest state
+    if (!retry) return;
+    if (showBtn && !clickShowTree(showBtn)) { settle(pane, null, true); hint(HINT_NO_HANDLER); return; }
+    // ctx identity is the guard: a close (which nulls ctx) or a re-open while the
+    // pane is still rendering must not have its results written by this pass.
+    var mine = ctx;
+    // This lands from a setInterval tick, NOT from the keydown handler, so it is
+    // outside onKeyCapture's try/catch - probe() carries its own guard so a
+    // throwing remote memoizedProps getter degrades to a warning + a hint instead
+    // of escaping as an unhandled page error.
+    function harvest() {
+      awaitProbe(pane, function (late, resolved) {
+        if (ctx !== mine || !isOpen()) return;
+        ctx.pane = resolved || pane;          // the ⋮ path resolves it only now
+        settle(ctx.pane, late, true);
+        hint(ctx.onPreview ? "" : (ctx.pane ? HINT_NO_HANDLER : HINT_NO_PANE));
+        // Clicking "Show file tree" (or the menu entry) ran upstream's own React
+        // handler, which can move focus into what it just rendered (the "Filter
+        // files" box). Take it back, or everything typed after lands there.
+        if (inputEl && document.activeElement !== inputEl) inputEl.focus();
+        run();
+      });
+    }
+    if (!opener) { harvest(); return; }
+    openFilesPane(opener, function (ok) {
+      if (ctx !== mine || !isOpen()) return;
+      if (!ok) { settle(null, null, false); hint(HINT_NO_PANE); return; }
+      harvest();
+    });
+  }
+  function close() {
+    if (debounceTimer) { clearTimeout(debounceTimer); debounceTimer = null; }
+    seq++;
+    if (rootEl && rootEl.parentNode) rootEl.parentNode.removeChild(rootEl);
+    rootEl = inputEl = listEl = hintEl = null;
+    items = []; sel = 0; ctx = null;
+  }
+  function hint(text) { if (hintEl) hintEl.textContent = text || ""; }
+
+  function run() {
+    if (!isOpen()) return;
+    var q = parseQuery(inputEl.value);
+    var my = ++seq;
+    if (!q.text) { render(mruItems()); return; }
+    search(q.text, function (list, err) {
+      if (my !== seq || !isOpen()) return;
+      if (err) { warnOnce("search-" + err, "fetchMentionOptions unavailable (" + err + ")"); hint("Search unavailable (" + err + ")"); render([]); return; }
+      render(toItems(list));
+    });
+  }
+  // Positions index the RELATIVE path; split them across dir and basename.
+  function highlighted(text, positions, offset) {
+    var frag = document.createDocumentFragment(), last = 0, set = {};
+    for (var i = 0; i < positions.length; i++) { var p = positions[i] - offset; if (p >= 0 && p < text.length) set[p] = true; }
+    for (var c = 0; c < text.length; c++) {
+      if (!set[c]) continue;
+      if (c > last) frag.appendChild(document.createTextNode(text.slice(last, c)));
+      var m = document.createElement("mark"); m.textContent = text.charAt(c); frag.appendChild(m);
+      last = c + 1;
+    }
+    if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+    return frag;
+  }
+  function render(arr) {
+    if (!isOpen()) return;
+    items = arr; sel = 0;
+    while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
+    for (var i = 0; i < items.length; i++) {
+      var it = items[i], slash = it.rel.lastIndexOf("/");
+      var name = it.rel.slice(slash + 1), dir = slash >= 0 ? it.rel.slice(0, slash) : "";
+      var li = el("li", "cdb-qopen-row");
+      li.setAttribute("role", "option");
+      li.setAttribute("aria-selected", i === sel ? "true" : "false");
+      li.setAttribute("data-index", String(i));
+      var nameEl = el("span", "cdb-qopen-name"); nameEl.appendChild(highlighted(name, it.positions, slash + 1));
+      var dirEl = el("span", "cdb-qopen-dir"); dirEl.appendChild(highlighted(dir, it.positions, 0));
+      li.appendChild(nameEl); li.appendChild(dirEl);
+      li.addEventListener("click", onRowClick);
+      li.addEventListener("mousemove", onRowHover);
+      listEl.appendChild(li);
+    }
+    if (ctx && ctx.pane && ctx.onPreview) {
+      var q = parseQuery(inputEl.value);
+      if (!q.text) hint(items.length ? HINT_MRU : HINT_EMPTY);
+      else if (!items.length) hint(HINT_NO_MATCH);
+      else if (ctx.root && items[0].abs.indexOf(ctx.root) !== 0) hint(HINT_OTHER_ROOT);
+      else hint(HINT_KEYS);
+    }
+  }
+  function select(i) {
+    if (!items.length) return;
+    sel = (i + items.length) % items.length;
+    var rows = listEl.children;
+    for (var k = 0; k < rows.length; k++) rows[k].setAttribute("aria-selected", k === sel ? "true" : "false");
+  }
+  function onRowHover(ev) { var i = parseInt(ev.currentTarget.getAttribute("data-index"), 10); if (i !== sel) select(i); }
+  function onRowClick(ev) { ev.preventDefault(); pick(parseInt(ev.currentTarget.getAttribute("data-index"), 10)); }
+  function pick(i) {
+    var it = items[i];
+    if (!it || !ctx || !ctx.onPreview) return;
+    // Prefer the tile's own root: the index follows the FOCUSED session's cwd,
+    // which can differ from the folder this tile shows (measured 2026-08-29).
+    var abs = ctx.root ? ctx.root + it.rel : it.abs;
+    var line = parseQuery(inputEl.value).line;
+    try { ctx.onPreview(abs, line); }
+    catch (e) { warnOnce("onpreview-threw", "onPreview threw: " + ((e && e.message) || e)); hint("Could not open " + it.rel); return; }
+    remember(it.rel);
+    close();
+  }
+  function onInputKey(ev) {
+    if (ev.key === "ArrowDown") { ev.preventDefault(); select(sel + 1); }
+    else if (ev.key === "ArrowUp") { ev.preventDefault(); select(sel - 1); }
+    else if (ev.key === "Enter") { ev.preventDefault(); pick(sel); }
+    else if (ev.key === "Escape") { ev.preventDefault(); ev.stopPropagation(); close(); }
+  }
+
+  // ---- global hotkey ------------------------------------------------------------
+  function inTerminal(node) {
+    try { return !!(node && node.closest && node.closest(".xterm")); } catch (e) { return false; }
+  }
+  function onCodeTab() { return /^\/epitaxy(\/|$)/.test(window.location.pathname); }
+  function onKeyCapture(ev) {
+    if (!enabled) return;
+    if (!ev.ctrlKey || ev.altKey || ev.metaKey || ev.shiftKey) return;
+    if (ev.key !== "p" && ev.key !== "P") return;
+    if (!onCodeTab()) return;
+    if (inTerminal(ev.target) || inTerminal(document.activeElement)) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    // open() walks REMOTE React fibers; a getter on memoizedProps that throws
+    // must not surface as an unhandled error inside claude.ai's own keydown path.
+    try { open(); }
+    catch (e) { warnOnce("open-threw", "open() threw while harvesting the Files pane: " + ((e && e.message) || e)); }
+  }
+
+  // ---- lifecycle ---------------------------------------------------------------
+  var prefTimer = null, started = false;
+  function start() {
+    if (started) return;
+    started = true;
+    window.addEventListener("keydown", onKeyCapture, true);
+    pollPref();
+    prefTimer = window.setInterval(pollPref, STATE_POLL_MS);
+  }
+  function stop() {
+    window.removeEventListener("keydown", onKeyCapture, true);
+    if (prefTimer) { clearInterval(prefTimer); prefTimer = null; }
+    close(); started = false;
+  }
+  function state() { return { enabled: enabled, open: isOpen(), items: items.map(function (i) { return i.rel; }), sel: sel, root: ctx ? ctx.root : null }; }
+
+  window.__cdbQuickOpenPage = { start: start, stop: stop, open: open, close: close, state: state, pollPref: pollPref };
+})();

--- a/js/files_quick_open_worker.js
+++ b/js/files_quick_open_worker.js
@@ -1,0 +1,143 @@
+/*
+ * files_quick_open_worker.js - the worker-side half of the Files quick open
+ * feature. Embedded at the head of upstream's file-index worker bundle
+ * (.vite/build/file-index-worker/fileIndexWorker.js) by
+ * patches/community/add_feature_files_quick_open_worker.nim, which also rewrites
+ * the ONE call site `this.index.search(query, limit)` inside
+ * FileIndexHost.search to `__cdbQoSearch(this.index, query, limit)`.
+ *
+ * WHY: upstream's scorer walks the query character by character with indexOf,
+ * so whitespace in the query has to occur literally in the path - "user
+ * service" returns nothing while "user-service" finds user-service.spec.ts.
+ * VS Code (src/vs/base/common/fuzzyScorer.ts) splits the query on spaces into
+ * pieces, requires EVERY piece to match (doScoreItemFuzzyMultiple returns
+ * NO_ITEM_SCORE otherwise), sums the piece scores and merges the match ranges.
+ * This helper ports exactly that on top of upstream's unchanged scorer - the
+ * MEMBERSHIP from upstream's own per-piece scans, the ORDER from a VS Code-style
+ * label-first score (__cdbQoScorePath below), because upstream only hands us an
+ * ordinal rank per piece and a sum of ordinals ranks directories above files.
+ *
+ * CONTRACT of `index` (upstream's scorer instance, class T in the worker):
+ *   index.readyCount           number of indexed paths (0 while building)
+ *   index.search(query, limit) -> [{ path, score: rank/n, positions: number[] }]
+ *                                 best first, at most `limit`
+ *
+ * GATE: process.env.CDB_FILES_QUICK_OPEN === "1". The main process mirrors the
+ * `filesQuickOpen` pref into that variable (js/files_quick_open_main.js) and
+ * Electron's utilityProcess.fork() passes main's env through unchanged, so a
+ * worker forked after the pref changed sees the new value. Off / unset means the
+ * query reaches upstream's scorer verbatim - a full retreat to stock behaviour.
+ *
+ * Utility-process module scope: a top-level function declaration here is
+ * visible to the rest of the bundle because the patch splices this file into
+ * the same module. Every name here carries the __cdbQo prefix so nothing in
+ * upstream's own module scope can be shadowed.
+ */
+// Is `needle` a subsequence of `hay`? (Both already case-folded by the caller.)
+function __cdbQoIsSubseq(hay, needle) {
+  var from = 0;
+  for (var i = 0; i < needle.length; i++) {
+    var at = hay.indexOf(needle.charAt(i), from);
+    if (at < 0) return false;
+    from = at + 1;
+  }
+  return true;
+}
+// How well ONE query piece describes the file NAME. VS Code scores the label
+// first and only falls back to the path/description when the label does not
+// match (fuzzyScorer.ts doScoreItemFuzzySingle: LABEL_PREFIX_SCORE_THRESHOLD
+// 1<<17 with a shortness boost > LABEL_SCORE_THRESHOLD 1<<16 > path).
+// Smart case, like upstream's own scorer: an uppercase character in the piece
+// makes the comparison case-sensitive; otherwise both sides are lowercased
+// (a piece with no uppercase character IS its own lowercase form).
+function __cdbQoScorePiece(base, piece) {
+  var b = /[A-Z]/.test(piece) ? base : base.toLowerCase();
+  var at = b.indexOf(piece);
+  if (at === 0) return 1000;                          // name starts with the piece
+  if (at > 0) return 700;                             // name contains it contiguously
+  if (__cdbQoIsSubseq(b, piece)) return 400;          // name contains it as a subsequence
+  return 100;                                         // matched only in the directory
+}
+// Total score for a candidate path. The AND-intersection already proved every
+// piece matches SOMEWHERE in the path, so the job here is only to order them.
+function __cdbQoScorePath(path, pieces) {
+  var slash = path.lastIndexOf("/");
+  var base = slash >= 0 ? path.slice(slash + 1) : path;
+  var score = 0;
+  for (var i = 0; i < pieces.length; i++) score += __cdbQoScorePiece(base, pieces[i]);
+  score += Math.max(0, 64 - base.length);             // VS Code's shortness boost
+  for (var c = 0; c < path.length; c++) if (path.charAt(c) === "/") score -= 2;   // depth penalty
+  return score;
+}
+function __cdbQoSearch(index, query, limit) {
+  "use strict";
+  var raw = String(query == null ? "" : query);
+  var on = false;
+  try { on = typeof process !== "undefined" && process.env && process.env.CDB_FILES_QUICK_OPEN === "1"; } catch (e) { on = false; }
+  if (!on) return index.search(raw, limit);
+
+  var pieces = raw.split(/\s+/).filter(function (p) { return p.length > 0; });
+  // Empty or single piece: upstream's own search, on the trimmed text (a trailing
+  // space would otherwise have to match a literal space in the path).
+  if (pieces.length === 0) return index.search(raw, limit);
+  if (pieces.length === 1) return index.search(pieces[0], limit);
+  // Bound the per-keystroke cost: at most 4 scans. Extra pieces are folded into
+  // the last one (still a subsequence, just longer).
+  var MAX_PIECES = 4;
+  if (pieces.length > MAX_PIECES) {
+    pieces = pieces.slice(0, MAX_PIECES - 1).concat([pieces.slice(MAX_PIECES - 1).join("")]);
+  }
+  if (typeof limit !== "number" || limit <= 0) return [];
+
+  // Every piece scans the WHOLE ready set: intersecting two top-N lists would
+  // drop a file that is a mediocre match for one piece and a great one for the
+  // other, which is precisely the "user service" case.
+  var total = (typeof index.readyCount === "number" && index.readyCount > 0) ? index.readyCount : 0;
+  if (total === 0) return [];
+
+  // Seed from the first piece: path -> { rank sum, positions }.
+  var first = index.search(pieces[0], total);
+  var acc = new Map();
+  for (var i = 0; i < first.length; i++) {
+    var r = first[i];
+    acc.set(r.path, { path: r.path, rank: i, positions: Array.prototype.slice.call(r.positions || []) });
+  }
+  // AND with every further piece; sum ranks (lower = better), union positions.
+  for (var k = 1; k < pieces.length && acc.size > 0; k++) {
+    var hits = index.search(pieces[k], total);
+    var byPath = new Map();
+    for (var j = 0; j < hits.length; j++) byPath.set(hits[j].path, { rank: j, positions: hits[j].positions || [] });
+    acc.forEach(function (entry, path) {
+      var h = byPath.get(path);
+      if (!h) { acc.delete(path); return; }
+      entry.rank += h.rank;
+      for (var q = 0; q < h.positions.length; q++) entry.positions.push(h.positions[q]);
+    });
+  }
+
+  // ORDER the intersection by a real score, not by the summed ordinal rank.
+  // Summing two ordinals is not a score: a short path that lands early in both
+  // per-piece scans (a DIRECTORY) then outranks the deep file the query actually
+  // describes - measured live on 1.40609.0, a two-word query put four sibling
+  // directories above the file it named, and adding a third word pushed that
+  // file out of the top four entirely.
+  // VS Code scores the label (file name) first, so score the basename and keep
+  // upstream's ordinal only as the TIE-BREAK - as a sort key, not as a term in
+  // the score: the summed ordinal is unbounded (readyCount per piece) and any
+  // scaled version of it would overpower the label tiers on a large index, which
+  // is the very bug this replaces. The result SET is untouched; only the order.
+  var merged = [];
+  acc.forEach(function (entry) { entry.qoScore = __cdbQoScorePath(entry.path, pieces); merged.push(entry); });
+  merged.sort(function (a, b) {
+    return b.qoScore - a.qoScore || a.rank - b.rank || (a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+  });
+  var out = merged.slice(0, limit);
+  var n = Math.max(out.length, 1);
+  return out.map(function (entry, idx) {
+    // Ascending + distinct, like VS Code's normalizeMatches.
+    var pos = entry.positions.slice().sort(function (a, b) { return a - b; });
+    var uniq = [];
+    for (var u = 0; u < pos.length; u++) if (u === 0 || pos[u] !== pos[u - 1]) uniq.push(pos[u]);
+    return { path: entry.path, score: idx / n, positions: uniq };
+  });
+}

--- a/patches/Makefile
+++ b/patches/Makefile
@@ -77,6 +77,9 @@ community/add_feature_panel_tabs: \
 
 community/add_feature_panel_tabs_bridge: ../js/panel_tabs_bridge.js
 
+# Files quick open: the worker patch embeds the multi-piece search helper.
+community/add_feature_files_quick_open_worker: ../js/files_quick_open_worker.js
+
 # Theme patch embeds the spinner-reshape installer (swaps the loading-star SVG
 # for the active theme's custom shape) and the bundled community + gaming palette
 # collections via staticRead.

--- a/patches/Makefile
+++ b/patches/Makefile
@@ -77,8 +77,16 @@ community/add_feature_panel_tabs: \
 
 community/add_feature_panel_tabs_bridge: ../js/panel_tabs_bridge.js
 
-# Files quick open: the worker patch embeds the multi-piece search helper.
+# Files quick open: the worker patch embeds the multi-piece search helper; the
+# main patch embeds the main-process module AND the page script; the bridge
+# patch embeds the preload snippet.
 community/add_feature_files_quick_open_worker: ../js/files_quick_open_worker.js
+
+community/add_feature_files_quick_open: \
+  ../js/files_quick_open_main.js \
+  ../js/files_quick_open_page.js
+
+community/add_feature_files_quick_open_bridge: ../js/files_quick_open_bridge.js
 
 # Theme patch embeds the spinner-reshape installer (swaps the loading-star SVG
 # for the active theme's custom shape) and the bundled community + gaming palette

--- a/patches/community/add_feature_files_quick_open.nim
+++ b/patches/community/add_feature_files_quick_open.nim
@@ -1,0 +1,145 @@
+# @patch-target: app.asar.contents/.vite/build/index.js
+# @patch-type: nim
+#
+# Files quick open - main-process half. Two sub-patches:
+#   A) injects js/files_quick_open_main.js with the page module
+#      (js/files_quick_open_page.js) embedded, at the head of the bundle;
+#   B) makes the generic utility-process host fork its workers with main's LIVE
+#      environment, which is what carries the CDB_FILES_QUICK_OPEN gate to the
+#      file-index worker.
+# Counterparts: patches/community/add_feature_files_quick_open_bridge.nim
+# (preload) and patches/community/add_feature_files_quick_open_worker.nim
+# (file index).
+#
+# WHY SUB-PATCH B (measured live on 1.40609.0, 2026-08-29): Electron's
+# utilityProcess.fork() with no `env` option does NOT hand the child the parent's
+# live process.env - it hands it the browser process's INITIAL environment. The
+# main half sets process.env.CDB_FILES_QUICK_OPEN at runtime, so with upstream's
+# default the key was absent from every utility process (/proc/<pid>/environ: 2062
+# entries in main, 2031-2064 in the workers, the key in none of them) and the
+# spaces fix silently stayed off while every build check was green. Upstream's own
+# MCP host passes `env:` explicitly for exactly this reason. So we pass it too, at
+# the ONE generic worker-host fork site: every worker that host spawns (file-index,
+# transcript-search, heavy-work, stall-sampler, ...) now inherits main's live env -
+# which is what the default was assumed to do anyway.
+#
+# What that widens: `Object.assign({},process.env)` forwards not just our gate but
+# everything upstream itself writes into main's env after startup - measured on
+# 1.37937.3: `CLAUDE_CODE_SESSION_ACCESS_TOKEN` and `CLAUDE_CONFIG_DIR` - to all
+# four of those workers, which the initial-env default did not. Same user, same
+# app, same trust domain (no process/user boundary is crossed), so this is an
+# exposure-surface widening rather than a boundary crossing; noted here because
+# it is the one behavioural side effect of B beyond the gate it was written for.
+#
+# The other three fork sites in the bundle are NOT touched and cannot match this
+# anchor: `Claude Desktop Shell Environment Extractor` (no stdio option), the MCP
+# host (`{...a,env:s}` - already passes env), and the pty host.
+#
+# Break risk: VERY LOW for A (stable head-of-bundle anchor, no regex on minified
+# code); LOW for B (minified identifiers are wildcards; the anchor is the
+# serviceName+stdio option shape and must match exactly once - see
+# baseline/FILES_QUICK_OPEN_ANCHORS.md for the grep recipe). The page half keys
+# off remote claude.ai DOM and fiber props and degrades to a no-op on a redeploy.
+
+import std/[os, strutils]
+import regex
+
+const MAIN_JS = staticRead("../../js/files_quick_open_main.js")
+const PAGE_JS = staticRead("../../js/files_quick_open_page.js")
+const MARKER = "__CDB_FILES_QUICK_OPEN__"
+const PLACEHOLDER = "\"__CDB_QOPEN_PAGE_SRC__\""
+const EXPECTED_PATCHES = 2  # A: page/main injection, B: worker-host env passthrough
+
+# Sub-patch B, measured 1.37937.3 and 1.40609.0 (exactly one occurrence in the
+# staged stub+chunks bundle):
+#   utilityProcess.fork(r,[],{serviceName:t,stdio:`pipe`})
+# Groups: 0 = the worker bundle path, 1 = the service name.
+let forkRe = re2"utilityProcess\.fork\(([\w$]+),\[\],\{serviceName:([\w$]+),stdio:`pipe`\}\)"
+# Our injected end-state, asserted positively (Rule 6) rather than inferred from
+# the absence of the pre-patch shape.
+const FORK_END_STATE = "stdio:`pipe`,env:Object.assign({},process.env)}"
+
+proc escapeJs(s: string): string =
+  result = s
+  result = result.replace("\\", "\\\\")
+  result = result.replace("\"", "\\\"")
+  result = result.replace("\n", "\\n")
+  result = result.replace("\r", "")
+
+proc buildInjection(): string =
+  if PLACEHOLDER notin MAIN_JS:
+    raise newException(ValueError, "files_quick_open_main.js lost its page-src placeholder")
+  let pageSrc = PAGE_JS & "\n;\nif(window.__cdbQuickOpenPage)window.__cdbQuickOpenPage.start();\n"
+  MAIN_JS.replace(PLACEHOLDER, "\"" & escapeJs(pageSrc) & "\"")
+
+proc apply*(input: string): string =
+  result = input
+  var patchesApplied = 0
+
+  # --- A: inject the main-process half (with the page module embedded) ---------
+  # Idempotency: positive end-state assertion (Rule 6).
+  if MARKER in result:
+    echo "  [OK] files quick open: injection already present (idempotent)"
+    inc patchesApplied
+  else:
+    let injection = buildInjection()
+    let strictPrefix = "\"use strict\";"
+    if result.startsWith(strictPrefix):
+      result = strictPrefix & injection & result[strictPrefix.len .. ^1]
+      echo "  [OK] files quick open injected after \"use strict\""
+    else:
+      result = injection & result
+      echo "  [OK] files quick open prepended"
+    if MARKER notin result:
+      echo "  [FAIL] files quick open: injection not present after patching"
+    else:
+      inc patchesApplied
+
+  # --- B: pass main's live env to the generic worker host ----------------------
+  let already = result.count(FORK_END_STATE)
+  if already == 1:
+    echo "  [OK] files quick open: worker host already forks with main's env (idempotent)"
+    inc patchesApplied
+  elif already > 1:
+    echo "  [FAIL] files quick open: worker-host env passthrough present " & $already &
+      " times, expected 1 - re-audit"
+  else:
+    var count = 0
+    result = result.replace(forkRe, proc(m: RegexMatch2, s: string): string =
+      inc count
+      "utilityProcess.fork(" & s[m.group(0)] & ",[],{serviceName:" & s[m.group(1)] &
+        ",stdio:`pipe`,env:Object.assign({},process.env)})"
+    )
+    if count != 1:
+      echo "  [FAIL] files quick open: expected exactly 1 generic worker-host fork site, found " &
+        $count & " - the CDB_FILES_QUICK_OPEN gate would never reach the file-index worker; re-audit"
+    elif result.count(FORK_END_STATE) != 1:
+      echo "  [FAIL] files quick open: worker-host env passthrough absent after patching"
+    else:
+      echo "  [OK] files quick open: worker host now forks with main's env"
+      inc patchesApplied
+
+  if patchesApplied < EXPECTED_PATCHES:
+    echo "  [FAIL] Only " & $patchesApplied & "/" & $EXPECTED_PATCHES & " patches applied"
+    quit(1)
+
+when isMainModule:
+  if paramCount() != 1:
+    echo "Usage: add_feature_files_quick_open <path_to_index.js>"
+    quit(1)
+  let filePath = paramStr(1)
+  echo "=== Patch: add_feature_files_quick_open ==="
+  echo "  Target: " & filePath
+  if not fileExists(filePath):
+    echo "  [FAIL] File not found: " & filePath
+    quit(1)
+  let input = readFile(filePath)
+  let output = apply(input)
+  if output != input:
+    writeFile(filePath, output)
+    echo "  [PASS] files quick open applied"
+  else:
+    if MARKER notin output or output.count(FORK_END_STATE) != 1:
+      echo "  [FAIL] No changes made and the end-state is absent"
+      quit(1)
+    echo "  [OK] Already applied (no changes needed)"

--- a/patches/community/add_feature_files_quick_open_bridge.nim
+++ b/patches/community/add_feature_files_quick_open_bridge.nim
@@ -1,0 +1,75 @@
+# @patch-target: app.asar.contents/.vite/build/mainView.js
+# @patch-type: nim
+#
+# contextBridge for the Files quick open feature (window.cdbQuickOpen).
+#
+# Break risk: VERY LOW - no regex against minified app code; the snippet is a
+# self-contained IIFE prepended to the head of the preload bundle.
+
+import std/[os, strutils]
+
+const BRIDGE_JS = staticRead("../../js/files_quick_open_bridge.js")
+
+# Directive prologues only take effect when they are the very first statement,
+# so if upstream ever re-introduces one we must inject *after* it rather than
+# in front of it. As of v1.26832.0 the bundle has none (it opens with the
+# Sentry release IIFE), so position 0 is the injection point.
+const DIRECTIVES = ["\"use strict\";", "'use strict';"]
+
+# Positive end-state markers (Rule 6): the build tag and the exposed global.
+const MARKERS = ["__cdb_files_quick_open_bridge", "exposeInMainWorld(\"cdbQuickOpen\""]
+
+proc markersPresent(s: string): int =
+  for m in MARKERS:
+    if m in s:
+      result.inc
+
+proc apply*(input: string): string =
+  result = input
+  let present = markersPresent(result)
+  if present == MARKERS.len:
+    echo "  [OK] cdbQuickOpen bridge already injected (idempotent)"
+    return
+  if present > 0:
+    echo "  [FAIL] Partial injection (" & $present & "/" & $MARKERS.len &
+      " markers) -- refusing to patch on top; re-audit the preload bundle"
+    quit(1)
+  # Precondition: still a sandboxed CommonJS preload that pulls in electron.
+  # Were it ever to become an ESM bundle, the injected require()/contextBridge
+  # IIFE would be wrong and must be re-authored instead of silently prepended.
+  if """require("electron")""" notin result and "require(`electron`)" notin result:
+    echo "  [FAIL] mainView.js does not require electron -- preload bundle shape changed (ESM?), re-audit"
+    quit(1)
+  var prologue = 0
+  for d in DIRECTIVES:
+    if result.startsWith(d):
+      prologue = d.len
+      break
+  result =
+    result[0 ..< prologue] & (if prologue > 0: "\n" else: "") & BRIDGE_JS &
+    result[prologue .. ^1]
+  if prologue > 0:
+    echo "  [OK] cdbQuickOpen bridge inserted after the directive prologue"
+  else:
+    echo "  [OK] cdbQuickOpen bridge prepended at the head of the preload"
+  if markersPresent(result) != MARKERS.len:
+    echo "  [FAIL] markers absent after patching"
+    quit(1)
+
+when isMainModule:
+  if paramCount() != 1:
+    echo "Usage: add_feature_files_quick_open_bridge <path_to_mainView.js>"
+    quit(1)
+  let filePath = paramStr(1)
+  echo "=== Patch: add_feature_files_quick_open_bridge ==="
+  echo "  Target: " & filePath
+  if not fileExists(filePath):
+    echo "  [FAIL] File not found: " & filePath
+    quit(1)
+  let input = readFile(filePath)
+  let output = apply(input)
+  if output != input:
+    writeFile(filePath, output)
+    echo "  [PASS] cdbQuickOpen bridge applied"
+  else:
+    echo "  [OK] Already applied (no changes needed)"

--- a/patches/community/add_feature_files_quick_open_worker.nim
+++ b/patches/community/add_feature_files_quick_open_worker.nim
@@ -1,0 +1,116 @@
+# @patch-target: app.asar.contents/.vite/build/file-index-worker/fileIndexWorker.js
+# @patch-type: nim
+#
+# Files quick open - worker half. Upstream's fuzzy file scorer treats a space in
+# the query as a literal character to find, so "user service" matches nothing.
+# This patch (1) prepends js/files_quick_open_worker.js, which defines
+# __cdbQoSearch(index, query, limit) - VS Code's multi-piece AND search on top of
+# the unchanged scorer, gated by process.env.CDB_FILES_QUICK_OPEN - and
+# (2) rewrites the ONE call site inside FileIndexHost.search:
+#     for(let{path:r,positions:i}of this.index.search(e,t))
+#  -> for(let{path:r,positions:i}of __cdbQoSearch(this.index,e,t))
+#
+# Break risk: LOW. The anchor is the structural shape of FileIndexHost.search
+# (a `let x=[]` followed by a for-of over this.index.search with the method's own
+# two parameters); every identifier is a wildcard and the parameter names are
+# cross-checked in the replacement. A second precondition pins `readyCount` on
+# the scorer, which the helper needs and the call-site anchor does not cover.
+
+import std/[os, strutils]
+import regex
+
+const HELPER_JS = staticRead("../../js/files_quick_open_worker.js")
+const MARKER = "__CDB_QOPEN_WORKER__"
+const DIRECTIVES = ["\"use strict\";", "'use strict';"]
+
+# The rewritten call site, matched by SHAPE rather than by the bare substring
+# "__cdbQoSearch(this.index," - that substring also occurs in the helper's own
+# doc comment, so a substring test would report "call present" the moment the
+# helper is prepended, even if the rewrite never happened (Rule 6: an [OK] must
+# rest on a positively verified end-state).
+let callRe = re2"\}of __cdbQoSearch\(this\.index,[\w$]+,[\w$]+\)\)"
+
+proc hasCallSite(s: string): bool = s.contains(callRe)
+
+# search(<q>,<lim>){let <acc>=[];if(this.index)for(let{path:<p>,positions:<pos>}of this.index.search(<q2>,<lim2>))
+# Groups: 0 = everything up to and including "of ", 1 = q, 2 = lim, 3 = q2, 4 = lim2
+let anchor = re2"(search\(([\w$]+),([\w$]+)\)\{let [\w$]+=\[\];if\(this\.index\)for\(let\{path:[\w$]+,positions:[\w$]+\}of )this\.index\.search\(([\w$]+),([\w$]+)\)\)"
+
+# PRECONDITION for the helper's multi-piece path: js/files_quick_open_worker.js
+# scans the WHOLE ready set per piece (`index.search(piece, index.readyCount)`),
+# because intersecting two top-N lists would drop the very files the space fix
+# exists for. If the scorer stops exposing `readyCount`, the helper reads
+# `undefined`, falls into `total === 0` and returns [] for every multi-piece
+# query - a SILENT regression the call-site anchor alone cannot catch. So pin it:
+# the scorer's search() destructures it off `this`
+# (measured 1.37937.3 and 1.40609.0: `{paths:u,lowerPaths:d,charBits:f,pathLens:p,readyCount:h}=this`)
+# and the field is assigned somewhere in the bundle.
+let readyCountRe = re2"readyCount:[\w$]+\}=this"
+
+proc apply*(input: string): string =
+  result = input
+  let hasMarker = MARKER in result
+  let hasCall = hasCallSite(result)
+  # Idempotency (Rule 6): BOTH halves of our end-state must be present.
+  if hasMarker and hasCall:
+    echo "  [OK] files quick open worker: helper + rewritten call already present (idempotent)"
+    return
+  if hasMarker != hasCall:
+    echo "  [FAIL] files quick open worker: partial injection (marker=" & $hasMarker &
+      " call=" & $hasCall & ") - refusing to patch on top; re-audit the worker bundle"
+    quit(1)
+
+  if not result.contains(readyCountRe) or "this.readyCount=" notin result:
+    echo "  [FAIL] files quick open worker: scorer no longer exposes readyCount - the helper's full-set scan would silently return nothing; re-audit"
+    quit(1)
+
+  var count = 0
+  result = result.replace(anchor, proc(m: RegexMatch2, s: string): string =
+    let q = s[m.group(1)]
+    let lim = s[m.group(2)]
+    if s[m.group(3)] != q or s[m.group(4)] != lim:
+      echo "  [FAIL] files quick open worker: inner search() args (" & s[m.group(3)] & "," &
+        s[m.group(4)] & ") are not the method parameters (" & q & "," & lim & ")"
+      quit(1)
+    inc count
+    s[m.group(0)] & "__cdbQoSearch(this.index," & q & "," & lim & "))"
+  )
+  if count != 1:
+    echo "  [FAIL] files quick open worker: expected exactly 1 FileIndexHost.search anchor, found " & $count
+    quit(1)
+
+  # Prepend the helper after the directive prologue (a directive only counts when
+  # it is the very first statement).
+  var prologue = 0
+  for d in DIRECTIVES:
+    if result.startsWith(d):
+      prologue = d.len
+      break
+  let helper = "\n/*" & MARKER & "*/\n" & HELPER_JS & "\n"
+  result = result[0 ..< prologue] & helper & result[prologue .. ^1]
+
+  if MARKER notin result or not hasCallSite(result):
+    echo "  [FAIL] files quick open worker: end-state absent after patching"
+    quit(1)
+  echo "  [OK] files quick open worker: helper prepended, FileIndexHost.search rewritten"
+
+when isMainModule:
+  if paramCount() != 1:
+    echo "Usage: add_feature_files_quick_open_worker <path_to_fileIndexWorker.js>"
+    quit(1)
+  let filePath = paramStr(1)
+  echo "=== Patch: add_feature_files_quick_open_worker ==="
+  echo "  Target: " & filePath
+  if not fileExists(filePath):
+    echo "  [FAIL] File not found: " & filePath
+    quit(1)
+  let input = readFile(filePath)
+  let output = apply(input)
+  if output != input:
+    writeFile(filePath, output)
+    echo "  [PASS] files quick open worker applied"
+  else:
+    if MARKER notin output or not hasCallSite(output):
+      echo "  [FAIL] No changes made and end-state is absent"
+      quit(1)
+    echo "  [OK] Already applied (no changes needed)"

--- a/scripts/apply_patches.py
+++ b/scripts/apply_patches.py
@@ -33,7 +33,7 @@ PATCH_SUBDIRS = ("linux", "core", "community")
 # forgotten `git mv` changes what gets discovered, the build must fail rather
 # than quietly ship a release with a patch missing. Bump this when you add or
 # remove a patch.
-EXPECTED_PATCH_COUNT = 44
+EXPECTED_PATCH_COUNT = 45
 
 
 def discover_patch_files(patches_dir: Path):

--- a/scripts/apply_patches.py
+++ b/scripts/apply_patches.py
@@ -33,7 +33,7 @@ PATCH_SUBDIRS = ("linux", "core", "community")
 # forgotten `git mv` changes what gets discovered, the build must fail rather
 # than quietly ship a release with a patch missing. Bump this when you add or
 # remove a patch.
-EXPECTED_PATCH_COUNT = 45
+EXPECTED_PATCH_COUNT = 47
 
 
 def discover_patch_files(patches_dir: Path):

--- a/scripts/run-feature-tests.sh
+++ b/scripts/run-feature-tests.sh
@@ -29,7 +29,7 @@ TESTS_DIR="$SCRIPT_DIR/tests"
 # `git mv` changes what gets discovered, this fails rather than quietly reporting
 # a green run over a shrunken suite - the same reasoning as EXPECTED_PATCH_COUNT
 # in scripts/apply_patches.py. Bump this when you add or remove a harness.
-EXPECTED_TEST_HARNESSES=14
+EXPECTED_TEST_HARNESSES=15
 
 CATEGORIES=(community core linux)
 

--- a/scripts/run-feature-tests.sh
+++ b/scripts/run-feature-tests.sh
@@ -29,7 +29,7 @@ TESTS_DIR="$SCRIPT_DIR/tests"
 # `git mv` changes what gets discovered, this fails rather than quietly reporting
 # a green run over a shrunken suite - the same reasoning as EXPECTED_PATCH_COUNT
 # in scripts/apply_patches.py. Bump this when you add or remove a harness.
-EXPECTED_TEST_HARNESSES=12
+EXPECTED_TEST_HARNESSES=13
 
 CATEGORIES=(community core linux)
 

--- a/scripts/run-feature-tests.sh
+++ b/scripts/run-feature-tests.sh
@@ -29,7 +29,7 @@ TESTS_DIR="$SCRIPT_DIR/tests"
 # `git mv` changes what gets discovered, this fails rather than quietly reporting
 # a green run over a shrunken suite - the same reasoning as EXPECTED_PATCH_COUNT
 # in scripts/apply_patches.py. Bump this when you add or remove a harness.
-EXPECTED_TEST_HARNESSES=13
+EXPECTED_TEST_HARNESSES=14
 
 CATEGORIES=(community core linux)
 

--- a/scripts/tests/community/test-files-quick-open-dom.mjs
+++ b/scripts/tests/community/test-files-quick-open-dom.mjs
@@ -1,0 +1,811 @@
+#!/usr/bin/env node
+/*
+ * test-files-quick-open-dom.mjs - headless-Chromium tests for the page half of
+ * the Files quick open feature (js/files_quick_open_page.js, delivered by
+ * patches/community/add_feature_files_quick_open.nim).
+ *
+ * The Files tile is REMOTE claude.ai markup, so a clean patch run proves
+ * nothing about this feature. The fixture reproduces what was measured live on
+ * 2026-08-29 (1.37937.3): a [data-pane-root][data-perf-screen="file"] pane with
+ * an input[aria-label="Filter files"], a [role=tree] of virtualized
+ * [role=treeitem] rows, and a React fiber chain on the rows whose ancestor
+ * exposes memoizedProps.onPreview(path, line, findQuery) and
+ * memoizedProps.entry = {name, absPath, relativePath, isDirectory, positions}.
+ * The `treeHidden` fixture reproduces the second shape, measured on 1.40609.0:
+ * the same pane with its tree COLLAPSED - no tree, no rows, no filter box, no
+ * onPreview anywhere - and upstream's "Show file tree" button as the way back.
+ * window["claude.web"].Resources.fetchMentionOptions and window.cdbQuickOpen
+ * are faked; every scenario reads its assertions back through a #__result sink.
+ *
+ * Exits 3 when Chromium is missing so the runner records SKIP.
+ * Usage: node scripts/tests/community/test-files-quick-open-dom.mjs [--keep] [--chromium PATH]
+ */
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { unescapeHtml } from "../lib/unescape-html.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const PAGE_SRC = readFileSync(join(ROOT, "js/files_quick_open_page.js"), "utf8");
+const argv = process.argv.slice(2);
+const KEEP = argv.includes("--keep");
+const CHROMIUM = (() => {
+  const i = argv.indexOf("--chromium");
+  if (i >= 0 && argv[i + 1]) return argv[i + 1];
+  for (const c of ["chromium", "chromium-browser", "google-chrome-stable", "google-chrome"]) {
+    try { const p = execFileSync("/bin/sh", ["-c", "command -v " + c], { encoding: "utf8" }).trim(); if (p) return p; } catch {}
+  }
+  return null;
+})();
+if (!CHROMIUM) { console.log("  SKIP: no chromium on PATH"); process.exit(3); }
+
+// The page module only arms Ctrl+P under /epitaxy, so every fixture needs a real
+// location.pathname. A file:// document cannot get one - Chrome rejects
+// history.replaceState from an opaque origin with a SecurityError (verified on
+// Chrome 152) - so the fixture is served over loopback HTTP instead and the path
+// comes from the URL itself. The server runs as a child process because
+// execFileSync(chromium) blocks this process's event loop.
+const SERVER_DIR = mkdtempSync(join(tmpdir(), "cdb-qopen-srv-"));
+const SERVER_SRC = `
+  const http = require("http"), fs = require("fs"), path = require("path");
+  const dir = process.argv[1];
+  http.createServer(function (req, res) {
+    let body;
+    try { body = fs.readFileSync(path.join(dir, "case.html")); }
+    catch (e) { res.writeHead(404); res.end(); return; }
+    res.writeHead(200, { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" });
+    res.end(body);
+  }).listen(0, "127.0.0.1", function () { fs.writeFileSync(path.join(dir, "port"), String(this.address().port)); });
+`;
+const SERVER = spawn(process.execPath, ["-e", SERVER_SRC, SERVER_DIR], { stdio: "ignore" });
+process.on("exit", () => {
+  try { SERVER.kill(); } catch {}
+  if (!KEEP) { try { rmSync(SERVER_DIR, { recursive: true, force: true }); } catch {} }
+});
+const PORT = (() => {
+  const nap = () => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+  for (let i = 0; i < 250; i++) {
+    try { const p = readFileSync(join(SERVER_DIR, "port"), "utf8").trim(); if (p) return p; } catch {}
+    nap();
+  }
+  throw new Error("fixture http server did not start");
+})();
+
+const ROOT_DIR = "/home/u/proj/";
+// Mirrors HINT_NO_HANDLER in js/files_quick_open_page.js.
+const HINT_NO_HANDLER = "Cannot open files: the Files panel changed (onPreview anchor missing)";
+const HINT_NO_PANE = "Open the Files panel first (Session actions → Files)";
+const HINT_OPENING_PANE = "Opening the Files panel…";
+const FILES = [
+  "modules/user/src/tests/user-run/use-cases/user-service.spec.ts",
+  "modules/user/src/domain/user-run/factories/user.service.ts",
+  "shared/package.json",
+  "shared/packages",           // reported as a directory by the fake index -> must be skipped
+  "README.md"
+];
+
+// The fake index: greedy subsequence over the relative path, spaces stripped
+// (the worker patch's job - this suite is about the PAGE), the upstream result
+// shape {id:"file-<abs>", label:<rel>, icon, category, metadata: JSON string}.
+const WIRING = `
+window.__calls = { preview: [], mention: [] };
+window.__errs = [];
+window.addEventListener("error", function (e) { window.__errs.push(String(e && e.message)); });
+// The page's contract is "degrade to a no-op plus ONE console.warn per key, never
+// a throw", so the warnings are an assertable artifact, not noise: a scenario that
+// makes a remote anchor throw checks __warns for the key AND __errs for silence.
+window.__warns = [];
+(function () {
+  var orig = console.warn;
+  console.warn = function () {
+    try { window.__warns.push(Array.prototype.join.call(arguments, " ")); } catch (e) {}
+    return orig.apply(console, arguments);
+  };
+})();
+var FIBER = "__reactFiber$test";
+var ROOT_DIR = ${JSON.stringify(ROOT_DIR)};
+var FILES = ${JSON.stringify(FILES)};
+function fuzzy(q, rel) {
+  var lp = rel.toLowerCase(), pos = [], from = 0;
+  for (var i = 0; i < q.length; i++) { var at = lp.indexOf(q[i], from); if (at < 0) return null; pos.push(at); from = at + 1; }
+  return pos;
+}
+window.__fakeMention = function (query, kind) {
+  window.__calls.mention.push([query, kind]);
+  var q = String(query).toLowerCase().replace(/\\s+/g, "");
+  var out = [];
+  for (var i = 0; i < FILES.length; i++) {
+    var rel = FILES[i], pos = q ? fuzzy(q, rel) : [];
+    if (pos === null) continue;
+    out.push({ id: "file-" + ROOT_DIR + rel, label: rel, icon: "file", category: "Files",
+      metadata: JSON.stringify({ path: rel, isDirectory: rel === "shared/packages", positions: pos }) });
+  }
+  return Promise.resolve(out);
+};
+window["claude.web"] = { Resources: { fetchMentionOptions: window.__fakeMention } };
+window.__prefState = { ok: true, enabled: true };
+window.cdbQuickOpen = { version: 1, state: function () { return Promise.resolve(window.__prefState); } };
+// Fiber chain, as measured: row node -> ... -> component with {entry, onPreview, onDrillInto}
+// The recorder maps an omitted argument to the string "undefined": the #__result sink
+// is JSON, and JSON.stringify would flatten a real undefined to null - which is exactly
+// the distinction "opened with NO line" vs "opened with a null line" needs to survive.
+window.__onPreview = function (path, line, findQuery) {
+  window.__calls.preview.push([path, line === undefined ? "undefined" : line, findQuery === undefined ? "undefined" : findQuery]);
+};
+// noHandler reproduces "the pane is there, the rows are there, but the fiber
+// ancestor no longer carries onPreview" - the shape an upstream refactor of the
+// tree component would produce. Everything else (entry props, tree list) stays.
+// __throwRowProps reproduces the nastiest remote shape: memoizedProps is an
+// accessor on the row's own fiber that THROWS when the page reads it. React does
+// not do this today, but the props object is remote code we do not control, and
+// the fiber walk must not turn it into an unhandled page error. Set it from a
+// scenario body BEFORE the rows are (re-)wired.
+window.__throwRowProps = false;
+window.__wireRow = function (row, rel, noHandler) {
+  var entry = { name: rel.split("/").pop(), absPath: ROOT_DIR + rel, relativePath: rel, isDirectory: false, positions: [] };
+  var props = { entry: entry, onDrillInto: function () {}, showPath: true };
+  if (!noHandler) props.onPreview = window.__onPreview;
+  var comp = { memoizedProps: props, return: null };
+  var mid = { memoizedProps: { onContextMenu: function () {} }, return: comp };
+  var leaf = { return: mid };
+  if (window.__throwRowProps)
+    Object.defineProperty(leaf, "memoizedProps", { get: function () { throw new Error("remote memoizedProps getter exploded"); } });
+  else leaf.memoizedProps = {};
+  row[FIBER] = leaf;
+};
+// Live on 1.40609.0 the walk up from the TREE (and from the filter box) finds no
+// onPreview at all - only a row reaches it. Fixtures that set treeNoHandler
+// reproduce that; the default keeps the handler on the tree's ancestor too, which
+// is what the "no rendered rows" scenario harvests from.
+window.__wireTree = function (tree, noHandler) {
+  var props = { results: [], isFetching: false, onDrillInto: function () {} };
+  if (!noHandler) props.onPreview = window.__onPreview;
+  var list = { memoizedProps: props, return: null };
+  tree[FIBER] = { memoizedProps: { role: "tree" }, return: list };
+};
+// Measured live: the component that owns onPreview also carries the folder the
+// tile shows as a string \`root\` prop, WITHOUT a trailing slash.
+window.__setRootProp = function (root) {
+  document.querySelectorAll("[role=treeitem]").forEach(function (r) { r[FIBER].return.return.memoizedProps.root = root; });
+  var t = document.querySelector("[data-test-tree]"); if (t) t[FIBER].return.memoizedProps.root = root;
+};
+window.__key = function (target, key, mods) {
+  var ev = new KeyboardEvent("keydown", Object.assign({ key: key, bubbles: true, cancelable: true }, mods || {}));
+  (target || document.body).dispatchEvent(ev);
+  return ev.defaultPrevented;
+};
+window.__ctrlP = function (target) { return window.__key(target, "p", { ctrlKey: true }); };
+window.__type = function (text) {
+  var inp = document.querySelector("#cdb-qopen input.cdb-qopen-input");
+  inp.value = text; inp.dispatchEvent(new Event("input", { bubbles: true }));
+  return inp;
+};
+window.__rows = function () { return Array.prototype.slice.call(document.querySelectorAll("#cdb-qopen [role=option]")); };
+window.__rowText = function () { return window.__rows().map(function (r) { return r.querySelector(".cdb-qopen-name").textContent + " | " + r.querySelector(".cdb-qopen-dir").textContent; }); };
+window.__hint = function () { var h = document.querySelector("#cdb-qopen .cdb-qopen-hint"); return h ? h.textContent : null; };
+window.__open = function () { return !!document.getElementById("cdb-qopen"); };
+window.__treeBtnLabel = function () { var b = document.querySelector("#host button"); return b ? b.getAttribute("aria-label") : null; };
+`;
+
+// treeHidden reproduces the live shape the page was blind to before: the Files
+// pane showing an open file with its tree COLLAPSED - no tree, no rows, no filter
+// box, nothing exposing onPreview - and upstream's "Show file tree" toolbar
+// button as the only way back. Clicking that button (a real listener here, as in
+// the app) renders exactly the markup + fibers the normal fixture starts with and
+// relabels the button, which is what the page waits for.
+function fixture(opts) {
+  const o = Object.assign({ pane: true, rows: true, handler: true, terminal: false,
+    treeHidden: false, showTreeBtn: true, treeNoHandler: false,
+    coldRows: null, coldDelayMs: 200, path: "/epitaxy/local_abc",
+    // No Files pane at all: upstream's session ⋮ menu is the only way to get one.
+    // Measured 1.40609.0: the ⋮ is NOT a sibling of the Terminal/Diff/Browser
+    // toolbar buttons - it sits 2 parents up, in the one ancestor that contains
+    // exactly one `More options for …` button. The menu renders async and its
+    // Files entry reads "FilesCtrlF" (label + shortcut, no separator).
+    paneOpener: false, filesMenuItem: true, menuDelayMs: 150, paneDelayMs: 300,
+    openedPaneTreeHidden: false,
+    // Measured 1.40609.0 on a pane opened from scratch: the tree renders with NO
+    // rows, and the component owning onPreview is reachable only by DESCENDING
+    // from the pane root - walking up from the tree or filter box finds nothing.
+    paneListFiber: false }, opts || {});
+  const rowsHtml = o.rows ? FILES.filter((f) => f !== "shared/packages").slice(0, 3).map((f, i) =>
+    `<div role="treeitem" aria-level="1" data-test-rel="${f}">${f.split("/").pop()}</div>`).join("") : "";
+  const treeHtml = `<input type="text" aria-label="Filter files" placeholder="Filter files… (? to search contents)">
+      <div role="tree" data-test-tree="">${rowsHtml}</div>`;
+  // COLD RENDER (measured 1.40609.0): the [role=tree] element commits BEFORE its
+  // rows. coldRows === false means they never arrive at all.
+  const emptyTreeHtml = `<input type="text" aria-label="Filter files" placeholder="Filter files… (? to search contents)">
+      <div role="tree" data-test-tree=""></div>`;
+  const paneBody = o.treeHidden
+    ? `${o.showTreeBtn ? `<button type="button" aria-label="Show file tree" aria-pressed="false">tree</button>` : ""}
+      <div data-test-editor="">README.md</div><div data-test-slot=""></div>`
+    : treeHtml;
+  const pane = o.pane ? `
+    <div data-pane-root="" data-perf-screen="file" class="epitaxy-view-panel">
+      <span>Files</span>
+      ${paneBody}
+    </div>` : "";
+  const term = o.terminal ? `<div data-pane-root="" data-perf-screen="terminal"><div class="xterm"><textarea class="xterm-helper-textarea" id="term-input"></textarea></div></div>` : "";
+  // Upstream's session header: the toolbar buttons in one wrapper, the ⋮ a level
+  // out - the shape the page's structural climb (seed → ancestor holding exactly
+  // one "More options for …") has to resolve.
+  const opener = o.paneOpener ? `
+    <div class="hdr-outer" style="display:flex">
+      <div class="hdr-inner" style="display:flex">
+        <button type="button" aria-label="Terminal">t</button>
+        <button type="button" aria-label="Diff (uncommitted changes)">d</button>
+        <button type="button" aria-label="Browser">b</button>
+      </div>
+      <button type="button" aria-label="More options for Test session">⋮</button>
+    </div>` : "";
+  // The pane the menu entry creates. Either shape is possible live: tree already
+  // rendered, or the pane arriving with its tree collapsed (then the page has to
+  // press "Show file tree" itself before anything exposes onPreview).
+  const openedPaneHtml = `<div data-pane-root="" data-perf-screen="file" class="epitaxy-view-panel"><span>Files</span>` +
+    (o.openedPaneTreeHidden
+      ? `<button type="button" aria-label="Show file tree" aria-pressed="false">tree</button><div data-test-editor="">README.md</div><div data-test-slot=""></div>`
+      : treeHtml) + `</div>`;
+  return { path: o.path, html: `<!doctype html><meta charset="utf-8">
+<div id="host">${opener}${pane}${term}</div>
+<pre id="__result"></pre>
+<script>${WIRING}</script>
+<script>
+  var NO_HANDLER = ${o.handler === false};
+  var TREE_NO_HANDLER = ${o.treeNoHandler === true};
+  var COLD = ${o.coldRows !== null}, COLD_ROWS = ${o.coldRows === true}, COLD_MS = ${o.coldDelayMs};
+  var PANE_LIST_FIBER = ${o.paneListFiber === true};
+  // The live shape: a list component below the pane root carries onPreview (and
+  // the tile's root prop), independent of whether any row is rendered.
+  window.__wirePaneList = function (pane) {
+    if (!pane) return;
+    var list = { memoizedProps: { sessionId: "s1", root: ROOT_DIR.substring(0, ROOT_DIR.length - 1),
+      listDirectory: function () {}, onPreview: window.__onPreview, prefetcher: {} }, child: null, sibling: null, return: null };
+    var mid = { memoizedProps: { className: "pane-body" }, child: list, sibling: null, return: null };
+    pane[FIBER] = { memoizedProps: {}, child: mid, sibling: null, return: null };
+  };
+  window.__wireAll = function () {
+    var tree = document.querySelector("[data-test-tree]"); if (tree) window.__wireTree(tree, NO_HANDLER || TREE_NO_HANDLER);
+    document.querySelectorAll("[role=treeitem]").forEach(function (r) { window.__wireRow(r, r.getAttribute("data-test-rel"), NO_HANDLER); });
+    if (PANE_LIST_FIBER) window.__wirePaneList(document.querySelector('[data-perf-screen="file"]'));
+  };
+  window.__wireAll();
+  var showBtn = document.querySelector('button[aria-label="Show file tree"]');
+  if (showBtn) showBtn.addEventListener("click", function () {
+    // WARM: tree + rows in one commit. COLD (measured 1.40609.0): the tree
+    // element commits first and its rows COLD_MS later - or never, when
+    // COLD_ROWS is false. The cold shape is what broke the open path: a poll
+    // that stops at "a tree exists" harvests nothing and never tries again.
+    document.querySelector("[data-test-slot]").innerHTML = COLD ? ${JSON.stringify(emptyTreeHtml)} : ${JSON.stringify(treeHtml)};
+    window.__wireAll();
+    showBtn.setAttribute("aria-label", "Hide file tree");
+    showBtn.setAttribute("aria-pressed", "true");
+    // Upstream's own React handler moves focus into the freshly rendered tree UI
+    // (its "Filter files" box). Our modal must take focus back, or every keystroke
+    // typed after the tree appears lands in upstream's filter instead.
+    var filter = document.querySelector('input[aria-label="Filter files"]');
+    if (filter) filter.focus();
+    // recorded so the "focus came back" assertion cannot pass vacuously
+    window.__filterStoleFocus = !!filter && document.activeElement === filter;
+    if (COLD && COLD_ROWS) setTimeout(function () {
+      var tree = document.querySelector("[data-test-tree]");
+      if (tree) { tree.innerHTML = ${JSON.stringify(rowsHtml)}; window.__wireAll(); }
+    }, COLD_MS);
+  });
+  // The session ⋮ → Files path, with upstream's own async stages: the menu renders
+  // after the click, and the pane mounts after the entry is chosen. __menuOpens /
+  // __filesClicks make "we drove upstream's real controls" provable, not assumed.
+  window.__menuOpens = 0; window.__filesClicks = 0;
+  var moreBtn = document.querySelector('button[aria-label^="More options for "]');
+  if (moreBtn) moreBtn.addEventListener("click", function () {
+    window.__menuOpens++;
+    if (document.getElementById("test-menu")) return;
+    setTimeout(function () {
+      var m = document.createElement("div");
+      m.id = "test-menu";
+      m.innerHTML = '<div role="menuitem">Artifacts</div>' +
+        (${o.filesMenuItem !== false} ? '<div role="menuitem">Files\\u2318CtrlF</div>' : "") +
+        '<div role="menuitem">Background tasks</div><div role="menuitem">Rename</div>';
+      document.body.appendChild(m);
+      // A real menu closes on Escape, so the fixture does too - but note that
+      // upstream's own menu on 1.40609.0 does NOT (measured: no synthetic event
+      // closes it). Live it stays mounted behind our overlay and goes away with
+      // it; this only asserts the page ATTEMPTS the dismissal, never that
+      // upstream obeys.
+      document.addEventListener("keydown", function esc(e) {
+        if (e.key !== "Escape") return;
+        document.removeEventListener("keydown", esc);
+        m.parentNode && m.parentNode.removeChild(m);
+      });
+      var items = m.querySelectorAll('[role=menuitem]');
+      for (var i = 0; i < items.length; i++) {
+        if (!/^files/i.test(items[i].textContent.replace(/[^\\x20-\\x7e]/g, "").trim())) continue;
+        items[i].addEventListener("click", function () {
+          window.__filesClicks++;
+          m.parentNode && m.parentNode.removeChild(m);
+          setTimeout(function () {
+            document.getElementById("host").insertAdjacentHTML("beforeend", ${JSON.stringify(openedPaneHtml)});
+            window.__wireAll();
+            var sb = document.querySelector('button[aria-label="Show file tree"]');
+            if (sb) sb.addEventListener("click", function () {
+              document.querySelector("[data-test-slot]").innerHTML = ${JSON.stringify(treeHtml)};
+              window.__wireAll();
+              sb.setAttribute("aria-label", "Hide file tree");
+            });
+          }, ${o.paneDelayMs});
+        });
+      }
+    }, ${o.menuDelayMs});
+  });
+  window.__cdbQoTestPollMs = 300;
+</script>
+<script>${PAGE_SRC}</script>
+<script>if (window.__cdbQuickOpenPage) window.__cdbQuickOpenPage.start();</script>
+<script>${o.body || ""}</script>` };
+}
+
+function run(fx, name, budgetMs) {
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-"));   // a per-scenario Chrome profile: no localStorage leaks between cases
+  writeFileSync(join(SERVER_DIR, "case.html"), fx.html);
+  try {
+    const dom = execFileSync(CHROMIUM, ["--headless", "--disable-gpu", "--no-sandbox",
+      "--user-data-dir=" + dir,
+      "--virtual-time-budget=" + (budgetMs || 2500), "--dump-dom",
+      "http://127.0.0.1:" + PORT + fx.path], { encoding: "utf8" });
+    const m = dom.match(/<pre id="__result">([\s\S]*?)<\/pre>/);
+    if (!m) throw new Error("no #__result sink in dumped DOM for " + name);
+    return JSON.parse(unescapeHtml(m[1]));
+  } finally { if (!KEEP) rmSync(dir, { recursive: true, force: true }); }
+}
+
+let pass = 0, fail = 0;
+const ok = (c, n) => { if (c) { pass++; console.log("  ok   " + n); } else { fail++; console.log("  FAIL " + n); } };
+const SINK = 'document.getElementById("__result").textContent = JSON.stringify';
+// Every scenario waits for the first pref poll (pref on) before pressing keys.
+const AFTER_PREF = (body) => `setTimeout(function () { ${body} }, 50);`;
+
+// --- open / close -----------------------------------------------------------------
+{
+  const r = run(fixture({ body: AFTER_PREF(`
+    var out = {};
+    out.prevented = window.__ctrlP();
+    out.open = window.__open();
+    out.focused = document.activeElement === document.querySelector("#cdb-qopen input.cdb-qopen-input");
+    out.role = document.querySelector("#cdb-qopen [role=dialog]") ? "dialog" : null;
+    window.__key(document.querySelector("#cdb-qopen input"), "Escape");
+    out.closedByEsc = !window.__open();
+    window.__ctrlP(); var again = window.__open(); window.__ctrlP(); out.toggleCloses = again && !window.__open();
+    window.__ctrlP(); document.querySelector("#cdb-qopen").dispatchEvent(new MouseEvent("mousedown", { bubbles: true })); out.backdropCloses = !window.__open();
+    ${SINK}(out);`) }), "open-close");
+  ok(r.prevented === true, "Ctrl+P is intercepted (preventDefault) on the Code tab with the pref on");
+  ok(r.open === true && r.role === "dialog", "the modal mounts as #cdb-qopen with a role=dialog box");
+  ok(r.focused === true, "the input has focus on open");
+  ok(r.closedByEsc === true, "Escape closes it");
+  ok(r.toggleCloses === true, "a second Ctrl+P closes it");
+  ok(r.backdropCloses === true, "a click on the backdrop closes it");
+}
+// --- search + render ----------------------------------------------------------------
+{
+  const r = run(fixture({ body: AFTER_PREF(`
+    window.__ctrlP(); window.__type("user service");
+    setTimeout(function () {
+      var out = { rows: window.__rowText(), marks: window.__rows()[0].querySelectorAll("mark").length,
+        mention: window.__calls.mention.slice(-1)[0], count: window.__rows().length };
+      out.noDirs = window.__rowText().every(function (t) { return t.indexOf("packages |") !== 0; });
+      ${SINK}(out);
+    }, 400);`) }), "search-render");
+  ok(r.mention && r.mention[0] === "user service" && r.mention[1] === "files", "the query goes to fetchMentionOptions(q, \"files\") verbatim (the worker handles spaces)");
+  ok(r.rows[0] === "user-service.spec.ts | modules/user/src/tests/user-run/use-cases", "row = basename | dirname: " + r.rows[0]);
+  ok(r.count === 2 && r.noDirs, "only the two user-service files render; the directory result is skipped");
+  ok(r.marks > 0, "match positions render as <mark>: " + r.marks);
+}
+{
+  // 15-row cap: a query every file matches ("") is the MRU path, so seed 20 fake files by
+  // overriding the fake and use a one-letter query.
+  const r = run(fixture({ body: AFTER_PREF(`
+    window["claude.web"].Resources.fetchMentionOptions = function (q) {
+      var out = []; for (var i = 0; i < 40; i++) out.push({ id: "file-" + ROOT_DIR + "f" + i + ".ts", label: "f" + i + ".ts", metadata: JSON.stringify({ path: "f" + i + ".ts", isDirectory: false, positions: [0] }) });
+      return Promise.resolve(out);
+    };
+    window.__ctrlP(); window.__type("f");
+    setTimeout(function () { ${SINK}({ count: window.__rows().length }); }, 400);`) }), "cap");
+  ok(r.count === 15, "at most 15 rows are rendered from a 40-result answer (" + r.count + ")");
+}
+// --- keyboard + mouse open ----------------------------------------------------------
+{
+  const r = run(fixture({ body: AFTER_PREF(`
+    window.__ctrlP(); window.__type("user service");
+    setTimeout(function () {
+      var inp = document.querySelector("#cdb-qopen input");
+      window.__key(inp, "ArrowDown");
+      var selIdx = window.__rows().findIndex(function (r) { return r.getAttribute("aria-selected") === "true"; });
+      window.__key(inp, "Enter");
+      var out = { selIdx: selIdx, preview: window.__calls.preview.slice(), closed: !window.__open() };
+      // mouse: reopen, click the first row
+      window.__ctrlP(); window.__type("user service");
+      setTimeout(function () {
+        window.__rows()[0].dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        out.previewAfterClick = window.__calls.preview.slice();
+        out.mru = JSON.parse(localStorage.getItem("cdb-qopen-mru:" + ROOT_DIR) || "[]");
+        ${SINK}(out);
+      }, 400);
+    }, 400);`) }), "pick");
+  ok(r.selIdx === 1, "ArrowDown moves the selection to the second row");
+  ok(r.preview.length === 1 && r.preview[0][0] === ROOT_DIR + "modules/user/src/domain/user-run/factories/user.service.ts" && r.preview[0][1] === "undefined",
+     "Enter calls onPreview(<tileRoot>/<rel>) of the selected row with no line: " + JSON.stringify(r.preview));
+  ok(r.closed === true, "the modal closes after opening a file");
+  ok(r.previewAfterClick.length === 2 && r.previewAfterClick[1][0] === ROOT_DIR + "modules/user/src/tests/user-run/use-cases/user-service.spec.ts",
+     "a mouse click opens that row");
+  ok(JSON.stringify(r.mru) === JSON.stringify(["modules/user/src/tests/user-run/use-cases/user-service.spec.ts", "modules/user/src/domain/user-run/factories/user.service.ts"]),
+     "MRU is most-recent-first under cdb-qopen-mru:<tileRoot>: " + JSON.stringify(r.mru));
+}
+{
+  const r = run(fixture({ body: AFTER_PREF(`
+    window.__ctrlP(); window.__type("readme:42");
+    setTimeout(function () {
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      ${SINK}({ preview: window.__calls.preview, mention: window.__calls.mention.slice(-1)[0] });
+    }, 400);`) }), "line-suffix");
+  ok(r.mention[0] === "readme", "a trailing :<n> is stripped from the search text");
+  ok(r.preview.length === 1 && r.preview[0][0] === ROOT_DIR + "README.md" && r.preview[0][1] === 42, "and passed to onPreview as the line: " + JSON.stringify(r.preview));
+}
+// --- MRU on empty query -------------------------------------------------------------
+{
+  const r = run(fixture({ body: `
+    localStorage.setItem("cdb-qopen-mru:" + ROOT_DIR, JSON.stringify(["shared/package.json", "README.md"]));
+    ${AFTER_PREF(`window.__ctrlP(); setTimeout(function () { ${SINK}({ rows: window.__rowText(), mention: window.__calls.mention.length }); }, 300);`)}` }), "mru");
+  ok(JSON.stringify(r.rows) === JSON.stringify(["package.json | shared", "README.md | "]), "empty query lists the MRU, most recent first: " + JSON.stringify(r.rows));
+  ok(r.mention === 0, "and does not call the index for an empty query");
+}
+// --- guards -----------------------------------------------------------------------
+{
+  const r = run(fixture({ pane: false, body: AFTER_PREF(`
+    window.__ctrlP(); var hint = window.__hint(); window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+    ${SINK}({ open: window.__open(), hint: hint, preview: window.__calls.preview.length });`) }), "no-pane");
+  ok(r.open === true && r.hint === "Open the Files panel first (Session actions → Files)", "no Files pane: the modal opens with the hint: " + r.hint);
+  ok(r.preview === 0, "and Enter opens nothing");
+}
+{
+  const r = run(fixture({ terminal: true, body: AFTER_PREF(`
+    var t = document.getElementById("term-input"); t.focus();
+    var prevented = window.__ctrlP(t);
+    ${SINK}({ prevented: prevented, open: window.__open() });`) }), "terminal-focus");
+  ok(r.prevented === false && r.open === false, "Ctrl+P inside an .xterm is left to the terminal");
+}
+{
+  const r = run(fixture({ path: "/new", body: AFTER_PREF(`${SINK}({ prevented: window.__ctrlP(), open: window.__open() });`) }), "not-code-tab");
+  ok(r.prevented === false && r.open === false, "outside /epitaxy the key is not intercepted");
+}
+{
+  const r = run(fixture({ body: AFTER_PREF(`
+    window.__ctrlP(); var wasOpen = window.__open();
+    window.__prefState = { ok: true, enabled: false };
+    setTimeout(function () { var closed = !window.__open(); var p = window.__ctrlP(); ${SINK}({ wasOpen: wasOpen, closed: closed, prevented: p, open: window.__open() }); }, 700);`) }), "pref-off", 3000);
+  ok(r.wasOpen === true && r.closed === true, "turning the pref off closes an open modal on the next poll");
+  ok(r.prevented === false && r.open === false, "and Ctrl+P is no longer intercepted");
+}
+{
+  // The bridge is gone by the time start()'s FIRST poll has already answered, so this
+  // scenario waits a full poll interval (300ms in test mode) for the page to notice.
+  const r = run(fixture({ body: `delete window.cdbQuickOpen;
+    setTimeout(function () { ${SINK}({ prevented: window.__ctrlP(), open: window.__open() }); }, 500);` }), "no-bridge");
+  ok(r.prevented === false && r.open === false, "no window.cdbQuickOpen: silent no-op");
+}
+{
+  const r = run(fixture({ rows: false, body: AFTER_PREF(`
+    window.__ctrlP(); window.__type("readme");
+    setTimeout(function () { window.__key(document.querySelector("#cdb-qopen input"), "Enter"); ${SINK}({ preview: window.__calls.preview }); }, 400);`) }), "no-rows");
+  ok(r.preview.length === 1 && r.preview[0][0] === ROOT_DIR + "README.md",
+     "with zero rendered rows the handler is harvested from the tree and the path comes from the index id: " + JSON.stringify(r.preview));
+}
+{
+  // Zero rendered rows -> no tile root. The MRU is keyed by that root and holds
+  // RELATIVE paths, so with no root it must be disabled in BOTH directions:
+  // never read (a root-less key would yield rows whose "absolute" path is the
+  // relative one, and upstream's onPreview does path.startsWith(...)) and never
+  // written (that key would shadow the real per-root MRU). Both keys are seeded.
+  const r = run(fixture({ rows: false, body: `
+    localStorage.setItem("cdb-qopen-mru:", JSON.stringify(["shared/package.json"]));
+    localStorage.setItem("cdb-qopen-mru:" + ROOT_DIR, JSON.stringify(["README.md"]));
+    ${AFTER_PREF(`
+      window.__ctrlP();
+      var out = { rows: window.__rows().length, hint: window.__hint() };
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.previewOnEmpty = window.__calls.preview.length;
+      window.__type("readme");
+      setTimeout(function () {
+        window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+        out.preview = window.__calls.preview.slice();
+        out.rootless = localStorage.getItem("cdb-qopen-mru:");
+        out.rooted = localStorage.getItem("cdb-qopen-mru:" + ROOT_DIR);
+        ${SINK}(out);
+      }, 400);`)}` }), "no-root-mru");
+  ok(r.rows === 0 && r.hint === "Type to search files in this session's folder",
+     "root unknown: an empty query renders no MRU rows and shows the neutral hint: " + r.rows + " / " + r.hint);
+  ok(r.previewOnEmpty === 0, "and Enter on that empty list opens nothing (no relative path reaches onPreview)");
+  ok(r.preview.length === 1 && r.preview[0][0] === ROOT_DIR + "README.md",
+     "a real search still opens the ABSOLUTE path from the index id: " + JSON.stringify(r.preview));
+  ok(r.rootless === JSON.stringify(["shared/package.json"]), "the root-less MRU key is not written: " + r.rootless);
+  ok(r.rooted === JSON.stringify(["README.md"]), "and the real per-root MRU is left alone: " + r.rooted);
+}
+{
+  // Pane and rows present, but the fiber ancestor lost onPreview: open, say so,
+  // and refuse to act - never guess another way into upstream's tree.
+  const r = run(fixture({ handler: false, body: AFTER_PREF(`
+    window.__ctrlP();
+    var out = { open: window.__open(), hint: window.__hint() };
+    window.__type("readme");
+    setTimeout(function () {
+      out.rowsRendered = window.__rows().length;
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.hintAfterSearch = window.__hint();
+      out.preview = window.__calls.preview.length;
+      ${SINK}(out);
+    }, 400);`) }), "no-onpreview");
+  ok(r.open === true && r.hint === HINT_NO_HANDLER, "pane present but no onPreview fiber: the modal opens with the hint: " + r.hint);
+  ok(r.rowsRendered > 0 && r.hintAfterSearch === HINT_NO_HANDLER, "the search still renders rows and the hint stays: " + r.rowsRendered + " / " + r.hintAfterSearch);
+  ok(r.preview === 0, "and Enter opens nothing");
+}
+// --- hidden file tree ---------------------------------------------------------------
+{
+  // The live defect (1.40609.0, 2026-08-29): the pane is open on a file with the
+  // tree collapsed, so nothing in it exposes onPreview and Ctrl+P could only ever
+  // say "the Files panel changed". Upstream's own button brings it all back.
+  const r = run(fixture({ treeHidden: true, body: AFTER_PREF(`
+    var out = { labelBefore: window.__treeBtnLabel(), treeBefore: !!document.querySelector("#host [role=tree]") };
+    window.__ctrlP();
+    out.open = window.__open(); out.hintWhileShowing = window.__hint();
+    window.__type("readme");
+    setTimeout(function () {
+      out.label = window.__treeBtnLabel();
+      out.rows = window.__rowText();
+      out.hint = window.__hint();
+      out.filterStoleFocus = window.__filterStoleFocus === true;
+      out.focusBack = document.activeElement === document.querySelector("#cdb-qopen input.cdb-qopen-input");
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.preview = window.__calls.preview.slice();
+      out.errs = window.__errs.slice();
+      ${SINK}(out);
+    }, 500);`) }), "tree-hidden");
+  ok(r.labelBefore === "Show file tree" && r.treeBefore === false,
+     "the fixture starts with the tree hidden behind the toolbar button: " + r.labelBefore + " / tree in DOM: " + r.treeBefore);
+  ok(r.open === true && r.hintWhileShowing === "Showing the file tree…",
+     "tree hidden: the modal still mounts at once, with the transient hint: " + r.hintWhileShowing);
+  ok(r.label === "Hide file tree", "upstream's \"Show file tree\" button was clicked (it now reads: " + r.label + ")");
+  ok(r.rows.length === 1 && r.hint === "↑↓ to select · Enter to open · :<line> to jump",
+     "once the tree renders the harvest re-runs: " + JSON.stringify(r.rows) + " / " + r.hint);
+  ok(r.preview.length === 1 && r.preview[0][0] === ROOT_DIR + "README.md",
+     "and Enter opens the file through the recovered onPreview: " + JSON.stringify(r.preview));
+  ok(r.errs.length === 0, "no error escaped into the page: " + JSON.stringify(r.errs));
+  ok(r.filterStoleFocus === true && r.focusBack === true,
+     "upstream's click moved focus to its \"Filter files\" box (" + r.filterStoleFocus +
+     ") and the modal took it back (" + r.focusBack + ")");
+}
+{
+  // Same hidden-tree path, but the rows upstream renders carry a memoizedProps
+  // ACCESSOR that throws. The harvest runs from a setInterval tick, outside the
+  // keydown handler's try/catch, so without its own guard the throw would surface
+  // as an unhandled page error. Contract: no-op + one warning + the honest hint.
+  const r = run(fixture({ treeHidden: true, body: AFTER_PREF(`
+    window.__throwRowProps = true;
+    window.__ctrlP();
+    var out = { open: window.__open() };
+    window.__type("readme");
+    setTimeout(function () {
+      out.stillOpen = window.__open();
+      out.hint = window.__hint();
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.preview = window.__calls.preview.length;
+      out.errs = window.__errs.slice();
+      out.warns = window.__warns.filter(function (w) { return w.indexOf("[cdb-qopen] open-threw") === 0; });
+      ${SINK}(out);
+    }, 500);`) }), "tree-hidden-props-throw");
+  ok(r.open === true && r.stillOpen === true, "a throwing row memoizedProps getter leaves the modal open");
+  ok(r.errs.length === 0, "and nothing escapes as a page error: " + JSON.stringify(r.errs));
+  ok(r.warns.length === 1, "exactly one [cdb-qopen] open-threw warning is recorded: " + JSON.stringify(r.warns));
+  ok(r.hint === HINT_NO_HANDLER && r.preview === 0,
+     "the hint says the anchor is gone and Enter opens nothing: " + r.hint);
+}
+{
+  // COLD RENDER - the live open-path defect (1.40609.0, 2026-08-29). The tree has
+  // been hidden since app start, so upstream commits the [role=tree] element
+  // FIRST and its rows ~200 ms later, and onPreview is reachable only from a ROW
+  // (treeNoHandler reproduces the measured fiber shape: the walk up from the tree
+  // returns null). A harvest that fires on "the tree exists" therefore finds
+  // nothing, gives up for good, and Enter opens nothing - what the user hit. The
+  // wait condition must be the harvest itself.
+  const r = run(fixture({ treeHidden: true, coldRows: true, treeNoHandler: true, body: AFTER_PREF(`
+    var out = {};
+    window.__ctrlP();
+    out.hintWhileShowing = window.__hint();
+    window.__type("readme");
+    setTimeout(function () {
+      out.rowsInPane = document.querySelectorAll("#host [role=treeitem]").length;
+      out.hint = window.__hint();
+      out.rows = window.__rowText();
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.preview = window.__calls.preview.slice();
+      out.errs = window.__errs.slice();
+      ${SINK}(out);
+    }, 900);`) }), "tree-hidden-cold-render", 4000);
+  ok(r.hintWhileShowing === "Showing the file tree…" && r.rowsInPane === 3,
+     "cold render: the tree element lands first and its rows only later (" + r.rowsInPane + " rows at the end)");
+  ok(r.hint !== HINT_NO_HANDLER && r.rows.length === 1,
+     "the retried harvest picks the handler up from the late row: hint " + JSON.stringify(r.hint));
+  ok(r.preview.length === 1 && r.preview[0][0] === ROOT_DIR + "README.md",
+     "and Enter opens the file through it: " + JSON.stringify(r.preview));
+  ok(r.errs.length === 0, "no error escaped into the page: " + JSON.stringify(r.errs));
+}
+{
+  // Same cold path, but the rows never arrive (an empty folder, or upstream's own
+  // filter matched nothing). After the budget the honest hint is all that is left
+  // - and it must arrive without a throw and without opening anything.
+  const r = run(fixture({ treeHidden: true, coldRows: false, treeNoHandler: true, body: AFTER_PREF(`
+    window.__ctrlP();
+    window.__type("readme");
+    setTimeout(function () {
+      var out = { open: window.__open(), hint: window.__hint(), rows: window.__rows().length };
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.preview = window.__calls.preview.length;
+      out.errs = window.__errs.slice();
+      out.warns = window.__warns.filter(function (w) { return w.indexOf("[cdb-qopen] ") === 0; });
+      ${SINK}(out);
+    }, 3400);`) }), "harvest-timeout", 7000);
+  ok(r.open === true && r.hint === HINT_NO_HANDLER,
+     "rows that never arrive: after the budget the modal is still open with the honest hint: " + r.hint);
+  ok(r.rows > 0 && r.preview === 0, "the search still rendered rows (" + r.rows + ") but Enter opens nothing");
+  ok(r.errs.length === 0, "and nothing throws: " + JSON.stringify(r.errs));
+  ok(r.warns.some((w) => w.indexOf("[cdb-qopen] harvest-timeout") === 0) &&
+     r.warns.some((w) => w.indexOf("[cdb-qopen] no-onpreview") === 0),
+     "the timeout is warned once, with the no-onpreview key: " + JSON.stringify(r.warns));
+}
+{
+  // Tree hidden and no button to press (an upstream relabel, or a pane that
+  // simply has no toggle): say so and refuse to act - never fake the tree open.
+  const r = run(fixture({ treeHidden: true, showTreeBtn: false, body: AFTER_PREF(`
+    window.__ctrlP();
+    var out = { open: window.__open(), hint: window.__hint() };
+    window.__type("readme");
+    setTimeout(function () {
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.hintAfter = window.__hint();
+      out.preview = window.__calls.preview.length;
+      out.errs = window.__errs.slice();
+      ${SINK}(out);
+    }, 500);`) }), "tree-hidden-no-button");
+  ok(r.open === true && r.hint === HINT_NO_HANDLER,
+     "tree hidden with no \"Show file tree\" button: the modal opens with the hint: " + r.hint);
+  ok(r.hintAfter === HINT_NO_HANDLER && r.preview === 0, "Enter opens nothing and the hint stays: " + r.hintAfter);
+  ok(r.errs.length === 0, "and nothing throws: " + JSON.stringify(r.errs));
+}
+{
+  // The tile root: the fiber that owns onPreview carries the folder as a string
+  // `root` prop (no trailing slash). It wins over the row-derived root, because
+  // the rows can belong to a different folder than the one the tile shows.
+  const r = run(fixture({ body: AFTER_PREF(`
+    window.__setRootProp("/home/u/other");
+    window.__ctrlP(); window.__type("readme");
+    setTimeout(function () {
+      var st = window.__cdbQuickOpenPage.state();
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      ${SINK}({ preview: window.__calls.preview.slice(), root: st.root });
+    }, 400);`) }), "fiber-root");
+  ok(r.root === "/home/u/other/", "the fiber's own root prop wins over the row-derived one (" + ROOT_DIR + "): " + r.root);
+  ok(r.preview.length === 1 && r.preview[0][0] === "/home/u/other/README.md",
+     "and the missing trailing slash is normalised before it is concatenated: " + JSON.stringify(r.preview));
+}
+
+// --- no Files pane at all: open it through upstream's own session menu ----------
+{
+  // The pane is closed, so nothing in the page exposes onPreview and there is no
+  // "Show file tree" button either. The only way in is upstream's session ⋮ →
+  // Files, and it has two async stages (menu, then pane) before the harvest can
+  // even start. Ctrl+P must still feel instant.
+  const r = run(fixture({ pane: false, paneOpener: true, body: AFTER_PREF(`
+    window.__ctrlP();
+    var early = { open: window.__open(), hint: window.__hint(), pane: !!document.querySelector('[data-perf-screen="file"]') };
+    window.__type("readme");
+    setTimeout(function () {
+      var out = { early: early, hint: window.__hint(), rows: window.__rows().length,
+        menuOpens: window.__menuOpens, filesClicks: window.__filesClicks,
+        paneNow: !!document.querySelector('[data-perf-screen="file"]'),
+        menuLeftOpen: !!document.getElementById("test-menu") };
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.preview = window.__calls.preview.slice();
+      out.errs = window.__errs.slice();
+      ${SINK}(out);
+    }, 1600);`) }), "no-pane-auto-open", 5000);
+  ok(r.early.open === true && r.early.pane === false,
+     "the modal mounts instantly, before any pane exists");
+  ok(r.early.hint === HINT_OPENING_PANE,
+     "and says what it is doing meanwhile: " + JSON.stringify(r.early.hint));
+  ok(r.menuOpens === 1 && r.filesClicks === 1,
+     "upstream's own ⋮ menu is opened once and its Files entry clicked once (" +
+     r.menuOpens + "/" + r.filesClicks + ")");
+  ok(r.paneNow === true, "which is what creates the Files pane");
+  ok(r.menuLeftOpen === false, "and the menu does not stay open over the app");
+  ok(r.hint !== HINT_NO_PANE && r.rows === 1,
+     "the harvest then lands and results render: hint " + JSON.stringify(r.hint) + ", rows " + r.rows);
+  ok(r.preview.length === 1 && r.preview[0][0] === ROOT_DIR + "README.md",
+     "Enter opens the file through the freshly created pane: " + JSON.stringify(r.preview));
+  ok(r.errs.length === 0, "no error escaped into the page: " + JSON.stringify(r.errs));
+}
+{
+  // The pane can arrive with its tree collapsed. That is the hidden-tree case one
+  // stage later, so the same poll has to press "Show file tree" itself.
+  const r = run(fixture({ pane: false, paneOpener: true, openedPaneTreeHidden: true, body: AFTER_PREF(`
+    window.__ctrlP(); window.__type("readme");
+    setTimeout(function () {
+      var out = { hint: window.__hint(), rows: window.__rows().length,
+        treeShown: !!document.querySelector('[role="tree"]') };
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.preview = window.__calls.preview.slice();
+      out.errs = window.__errs.slice();
+      ${SINK}(out);
+    }, 2000);`) }), "no-pane-then-hidden-tree", 5000);
+  ok(r.treeShown === true, "a pane that mounts with its tree collapsed gets the tree shown too");
+  ok(r.preview.length === 1 && r.preview[0][0] === ROOT_DIR + "README.md",
+     "and the file still opens: " + JSON.stringify(r.preview));
+  ok(r.errs.length === 0, "no error escaped into the page: " + JSON.stringify(r.errs));
+}
+{
+  // Upstream's menu is there but has no Files entry (an anchor that moved, or a
+  // session that cannot show files). Degrade to the honest hint - never hang.
+  const r = run(fixture({ pane: false, paneOpener: true, filesMenuItem: false, body: AFTER_PREF(`
+    window.__ctrlP(); window.__type("readme");
+    setTimeout(function () {
+      var out = { hint: window.__hint(), menuOpens: window.__menuOpens,
+        paneNow: !!document.querySelector('[data-perf-screen="file"]'),
+        menuLeftOpen: !!document.getElementById("test-menu") };
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.preview = window.__calls.preview.length;
+      out.errs = window.__errs.slice();
+      out.warns = window.__warns.filter(function (w) { return w.indexOf("[cdb-qopen] ") === 0; });
+      ${SINK}(out);
+    }, 2600);`) }), "no-pane-no-files-entry", 5000);
+  ok(r.menuOpens === 1 && r.paneNow === false, "the menu is tried once and yields no pane");
+  ok(r.hint === HINT_NO_PANE, "the hint falls back to the honest one: " + JSON.stringify(r.hint));
+  ok(r.menuLeftOpen === false, "the menu is dismissed rather than left hanging over the app");
+  ok(r.preview === 0, "Enter opens nothing");
+  ok(r.warns.some(function (w) { return w.indexOf("[cdb-qopen] no-files-menu-item") === 0; }),
+     "and the missing entry is warned once: " + JSON.stringify(r.warns));
+  ok(r.errs.length === 0, "no error escaped into the page: " + JSON.stringify(r.errs));
+}
+{
+  // No pane AND no session menu to reach one (upstream moved the toolbar, or this
+  // surface has none): the pre-existing behaviour, unchanged.
+  const r = run(fixture({ pane: false, body: AFTER_PREF(`
+    window.__ctrlP();
+    ${SINK}({ open: window.__open(), hint: window.__hint(), errs: window.__errs.slice() });`) }), "no-pane-no-opener");
+  ok(r.open === true && r.hint === HINT_NO_PANE,
+     "with no way to open a pane the modal still opens and says so: " + JSON.stringify(r.hint));
+  ok(r.errs.length === 0, "no error escaped into the page: " + JSON.stringify(r.errs));
+}
+
+{
+  // A pane opened from scratch renders its tree with NO rows for a while
+  // (measured 1.40609.0). Walking up from the tree or the filter box finds
+  // nothing then - only descending from the pane root reaches the component that
+  // owns onPreview. Without that descent the harvest times out on every
+  // freshly-opened pane, which is exactly the case the ⋮ path creates.
+  const r = run(fixture({ rows: false, paneListFiber: true, body: AFTER_PREF(`
+    window.__ctrlP(); window.__type("readme");
+    setTimeout(function () {
+      var out = { hint: window.__hint(), rowsInPane: document.querySelectorAll('[role=treeitem]').length,
+        rows: window.__rows().length, root: window.__cdbQuickOpenPage.state().root };
+      window.__key(document.querySelector("#cdb-qopen input"), "Enter");
+      out.preview = window.__calls.preview.slice();
+      out.errs = window.__errs.slice();
+      ${SINK}(out);
+    }, 700);`) }), "empty-tree-list-fiber");
+  ok(r.rowsInPane === 0, "the pane's tree really is row-less in this shape");
+  ok(r.hint !== HINT_NO_HANDLER && r.root === ROOT_DIR,
+     "the handler is still found by descending, root and all: " + JSON.stringify(r.root));
+  ok(r.preview.length === 1 && r.preview[0][0] === ROOT_DIR + "README.md",
+     "and Enter opens the file: " + JSON.stringify(r.preview));
+  ok(r.errs.length === 0, "no error escaped into the page: " + JSON.stringify(r.errs));
+}
+
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail ? 1 : 0);

--- a/scripts/tests/community/test-files-quick-open-main.mjs
+++ b/scripts/tests/community/test-files-quick-open-main.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/*
+ * test-files-quick-open-main.mjs - the main-process half of the Files quick open feature.
+ * A clean patch run says nothing about WHICH file the pref is written to or
+ * whether a .jsonc lock wins, so this suite runs the real module with electron
+ * shimmed and a temporary profile dir. Exit 3 = a required tool is missing.
+ */
+import { readFileSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+import Module from "node:module";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+let pass = 0, fail = 0;
+const ok = (c, n) => { if (c) { pass++; console.log("  ok   " + n); }
+  else { fail++; console.log("  FAIL " + n); } };
+
+// getPath: pass a string for a real profile dir, or null to simulate no
+// userData path at all (electron.app.getPath throwing, e.g. before ready).
+function load(profileDir, env) {
+  const handlers = {};
+  const electron = {
+    app: {
+      getPath: () => { if (profileDir === null) throw new Error("no app"); return profileDir; },
+      on: () => {}
+    },
+    ipcMain: { handle: (ch, fn) => { handlers[ch] = fn; } }
+  };
+  const src = readFileSync(join(ROOT, "js/files_quick_open_main.js"), "utf8")
+    .replace('"__CDB_QOPEN_PAGE_SRC__"', '"/*page*/"');
+  const sandbox = { require: (m) => (m === "electron" ? electron : Module.createRequire(import.meta.url)(m)),
+    process: { platform: "linux", env: env || {} }, console, globalThis: {}, setTimeout };
+  sandbox.globalThis = sandbox;
+  vm.runInNewContext(src, vm.createContext(sandbox));
+  return handlers;
+}
+
+// A real webContents always has isDestroyed(); okSender must fail CLOSED if
+// it is ever missing (Finding 3), so every fake sender below carries one.
+function sender(url) { return { sender: { getURL: () => url, isDestroyed: () => false } }; }
+const okSenderEv = sender("https://claude.ai/epitaxy");
+
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-"));
+  const h = load(dir);
+  ok(typeof h["cdb-qopen:state"] === "function", "registers cdb-qopen:state");
+  ok(typeof h["cdb-qopen:pref-read"] === "function", "registers cdb-qopen:pref-read");
+  ok(typeof h["cdb-qopen:pref-set"] === "function", "registers cdb-qopen:pref-set");
+
+  const initial = await h["cdb-qopen:pref-read"](okSenderEv);
+  ok(initial.ok === true && initial.enabled === false, "pref defaults to off (opt-in)");
+
+  const set = await h["cdb-qopen:pref-set"](okSenderEv, true);
+  ok(set.ok === true && set.enabled === true, "pref-set turns the feature on");
+  const after = await h["cdb-qopen:pref-read"](okSenderEv);
+  ok(after.enabled === true, "pref survives a re-read from disk");
+  const st = await h["cdb-qopen:state"](okSenderEv);
+  ok(st.ok === true && st.enabled === true, "state reports the pref");
+
+  const bad = await h["cdb-qopen:pref-set"](okSenderEv, "yes");
+  ok(bad.ok === false, "pref-set rejects a non-boolean");
+
+  // (a) WHICH FILE the pref landed in: read claude-desktop-extra.json back
+  // directly. An implementation that (mistakenly) wrote the .jsonc instead
+  // would pass every check above while failing this one.
+  const onDisk = JSON.parse(readFileSync(join(dir, "claude-desktop-extra.json"), "utf8"));
+  ok(onDisk.filesQuickOpen === true, "pref-set actually wrote claude-desktop-extra.json");
+
+  // (e) pref-set(false) round-trips, and going back to the default value
+  // removes the key entirely rather than writing `"filesQuickOpen": false`.
+  const off = await h["cdb-qopen:pref-set"](okSenderEv, false);
+  ok(off.ok === true && off.enabled === false, "pref-set(false) turns the feature back off");
+  const offDisk = JSON.parse(readFileSync(join(dir, "claude-desktop-extra.json"), "utf8"));
+  ok(!("filesQuickOpen" in offDisk), "setting back to the default removes the key rather than writing false");
+
+  rmSync(dir, { recursive: true, force: true });
+}
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-"));
+  writeFileSync(join(dir, "claude-desktop-extra.jsonc"),
+    '{\n  // locked by the operator\n  "filesQuickOpen": false\n}\n');
+  // A .json also exists while the .jsonc holds the lock - it must come out
+  // byte-for-byte unchanged after a refused pref-set (Finding 1 / gap c: a
+  // "refuse but write anyway" bug would corrupt or touch this file).
+  const jsonPath = join(dir, "claude-desktop-extra.json");
+  const untouchedContent = '{\n  "someOtherExtra": "leave me alone"\n}\n';
+  writeFileSync(jsonPath, untouchedContent);
+
+  const h = load(dir);
+  const read = await h["cdb-qopen:pref-read"](okSenderEv);
+  ok(read.lockedByJsonc === true, "a .jsonc value reports lockedByJsonc");
+  const set = await h["cdb-qopen:pref-set"](okSenderEv, true);
+  ok(set.ok === false && /claude-desktop-extra\.jsonc/.test(set.error),
+     "pref-set refuses while the .jsonc holds the key");
+  ok(readFileSync(jsonPath, "utf8") === untouchedContent,
+     "a refused (locked) pref-set does not touch the .json at all");
+  rmSync(dir, { recursive: true, force: true });
+}
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-"));
+  const h = load(dir);
+  const res = await h["cdb-qopen:pref-set"](sender("https://evil.example"), true);
+  ok(res.ok === false && /sender/.test(res.error), "rejects an unrecognised sender");
+  rmSync(dir, { recursive: true, force: true });
+}
+// A naive "//"-strips-to-end-of-line .jsonc stripper corrupts any string value
+// that happens to contain "//" without a preceding colon (e.g. a path, not a
+// URL) - it is not enough to special-case "://". Guard against that class of
+// bug directly, independent of whichever regex the implementation uses.
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-"));
+  writeFileSync(join(dir, "claude-desktop-extra.json"),
+    '{\n  "filesQuickOpen": true,\n  "note": "see a//b for details"\n}\n');
+  const h = load(dir);
+  const read = await h["cdb-qopen:pref-read"](okSenderEv);
+  ok(read.ok === true && read.enabled === true,
+     ".jsonc/.json comment-stripping does not corrupt a string value containing //");
+  rmSync(dir, { recursive: true, force: true });
+}
+// The sender check must compare the ORIGIN, not merely test whether the URL
+// string contains "claude.ai"/"claude.com" as a substring - the latter would
+// wave through a lookalike host that embeds the real domain as a path segment
+// or subdomain label.
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-"));
+  const h = load(dir);
+  const res = await h["cdb-qopen:pref-set"](sender("https://evil.example/?next=claude.ai"), true);
+  ok(res.ok === false, "rejects a sender whose URL merely contains \"claude.ai\" as a substring");
+  rmSync(dir, { recursive: true, force: true });
+}
+// (d) POSITIVE origin coverage: a typo that dropped three of the four
+// allowlist entries would still pass every rejection test above. Assert each
+// allowed origin is actually accepted.
+{
+  const allowedUrls = [
+    "https://claude.ai/x",
+    "https://preview.claude.ai/x",
+    "https://claude.com/x",
+    "https://preview.claude.com/x"
+  ];
+  for (const url of allowedUrls) {
+    const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-"));
+    const h = load(dir);
+    const res = await h["cdb-qopen:state"](sender(url));
+    ok(res.ok === true, "accepts an allowed sender origin: " + url);
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+// (b) sibling keys survive a write: another extra's key already in the .json
+// must still be present after pref-set writes ours next to it.
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-"));
+  const jsonPath = join(dir, "claude-desktop-extra.json");
+  writeFileSync(jsonPath, JSON.stringify({ customThemes: ["mine"], coworkGlow: true }, null, 2) + "\n");
+  const h = load(dir);
+  const set = await h["cdb-qopen:pref-set"](okSenderEv, true);
+  ok(set.ok === true, "pref-set succeeds when sibling keys already exist");
+  const disk = JSON.parse(readFileSync(jsonPath, "utf8"));
+  ok(disk.filesQuickOpen === true, "our key is present after the write");
+  ok(JSON.stringify(disk.customThemes) === JSON.stringify(["mine"]) && disk.coworkGlow === true,
+     "sibling keys (customThemes, coworkGlow) survive the write untouched");
+  rmSync(dir, { recursive: true, force: true });
+}
+// Finding 1: an existing-but-unparseable .json must be REFUSED, not silently
+// treated as empty and overwritten - the latter would wipe every other
+// extra's settings while reporting success. Nothing may be written.
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-"));
+  const jsonPath = join(dir, "claude-desktop-extra.json");
+  const broken = '{"customThemes":["mine"],"coworkGlow":true,"diffViews":true,"oops": ,}';
+  writeFileSync(jsonPath, broken);
+  const h = load(dir);
+  const set = await h["cdb-qopen:pref-set"](okSenderEv, true);
+  ok(set.ok === false, "pref-set refuses when the existing .json is not valid JSON");
+  ok(readFileSync(jsonPath, "utf8") === broken,
+     "an unparseable .json is left byte-for-byte unchanged - nothing was written");
+  rmSync(dir, { recursive: true, force: true });
+}
+// (e) the no-userData-path failure mode: electron.app.getPath is unavailable
+// (e.g. called before the app is ready). Reads fall back to the default;
+// pref-set must fail explicitly instead of throwing or silently no-oping.
+{
+  const h = load(null);
+  const read = await h["cdb-qopen:pref-read"](okSenderEv);
+  ok(read.ok === true && read.enabled === false, "pref-read falls back to the default with no userData path");
+  const set = await h["cdb-qopen:pref-set"](okSenderEv, true);
+  ok(set.ok === false, "pref-set fails explicitly with no userData path, instead of throwing");
+}
+
+// --- THE TWO SENDER GUARDS, which had ZERO coverage -----------------------------
+// Proven vacuous by a reviewer: deleting BOTH `wc.isDestroyed()` and the
+// `senderFrame`/`frame.parent` subframe check left 28/28 passing, because every fake
+// sender above carries an isDestroyed and no case ever built a destroyed sender, a
+// sender missing the method, or a subframe sender. Both are security controls.
+//
+// Each variant below uses an ALLOWED origin, so the only thing that can reject it is
+// the guard under test.
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-guards-"));
+  const h = load(dir);
+  const CHANNELS = ["cdb-qopen:state", "cdb-qopen:pref-read", "cdb-qopen:pref-set"];
+
+  // (a) a DESTROYED webContents - the window went away mid-flight.
+  const destroyed = { sender: { getURL: () => "https://claude.ai/epitaxy", isDestroyed: () => true } };
+  for (const ch of CHANNELS) {
+    const res = await h[ch](destroyed, true);
+    ok(res.ok === false && /unrecognized sender/.test(res.error || ""),
+       "guard: " + ch + " rejects a DESTROYED sender, allowed origin notwithstanding");
+  }
+
+  // (b) isDestroyed MISSING entirely. This must fail CLOSED through the catch, not be
+  //     read as "not destroyed" - the comment at files_quick_open_main.js (okSender) promises exactly
+  //     that, and nothing tested it.
+  const noMethod = { sender: { getURL: () => "https://claude.ai/epitaxy" } };
+  for (const ch of CHANNELS) {
+    const res = await h[ch](noMethod, true);
+    ok(res.ok === false && /unrecognized sender/.test(res.error || ""),
+       "guard: " + ch + " rejects a sender with NO isDestroyed - fail closed, never 'assume fine'");
+  }
+
+  // (c) a SUBFRAME sender: an iframe inside an allowed page must not reach these
+  //     channels. `senderFrame.parent` is the discriminator.
+  const subframe = { sender: { getURL: () => "https://claude.ai/epitaxy", isDestroyed: () => false },
+    senderFrame: { parent: {} } };
+  for (const ch of CHANNELS) {
+    const res = await h[ch](subframe, true);
+    ok(res.ok === false && /unrecognized sender/.test(res.error || ""),
+       "guard: " + ch + " rejects a SUBFRAME sender even on an allowed origin");
+  }
+
+  // (d) and the guards must not have made the legitimate path unreachable: a top-level
+  //     frame (senderFrame present, parent null) on an allowed origin still works.
+  const topFrame = { sender: { getURL: () => "https://claude.ai/epitaxy", isDestroyed: () => false },
+    senderFrame: { parent: null } };
+  const okRes = await h["cdb-qopen:pref-read"](topFrame);
+  ok(okRes.ok === true,
+     "guard: a TOP-LEVEL frame on an allowed origin is still accepted - the checks reject subframes, not everything");
+
+  // (e) pref-set specifically must not have written anything on any rejected call.
+  const after = await h["cdb-qopen:pref-read"](okSenderEv);
+  ok(after.ok === true && after.enabled === false,
+     "guard: none of the rejected pref-set calls changed the stored pref");
+}
+
+// The worker half reads process.env.CDB_FILES_QUICK_OPEN; main must mirror the pref
+// into it at load AND on every pref-set, or a toggle would never reach the index.
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-env-"));
+  const env = {};
+  const h = load(dir, env);
+  ok(env.CDB_FILES_QUICK_OPEN === "0", "env mirror: off at load when the pref is unset (" + env.CDB_FILES_QUICK_OPEN + ")");
+  await h["cdb-qopen:pref-set"](okSenderEv, true);
+  ok(env.CDB_FILES_QUICK_OPEN === "1", "env mirror: \"1\" after pref-set(true)");
+  await h["cdb-qopen:pref-set"](okSenderEv, false);
+  ok(env.CDB_FILES_QUICK_OPEN === "0", "env mirror: back to \"0\" after pref-set(false)");
+  rmSync(dir, { recursive: true, force: true });
+}
+// The gate the WORKER reads must also be reportable back to the page: a live check
+// on 1.40609.0 found the switch on, the patched asar in place and the index still
+// splitting nothing, because the env value never reached the utility process. Both
+// read channels therefore carry envGate - the value the worker gate holds right
+// now ("1"/"0", or null when it was never written).
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-env-"));
+  const env = {};
+  const h = load(dir, env);
+  const state0 = await h["cdb-qopen:state"](okSenderEv);
+  const read0 = await h["cdb-qopen:pref-read"](okSenderEv);
+  ok(state0.envGate === "0" && read0.envGate === "0",
+     "envGate reports \"0\" on state and pref-read with the pref unset (" + state0.envGate + "/" + read0.envGate + ")");
+  await h["cdb-qopen:pref-set"](okSenderEv, true);
+  const state1 = await h["cdb-qopen:state"](okSenderEv);
+  const read1 = await h["cdb-qopen:pref-read"](okSenderEv);
+  ok(state1.envGate === "1" && read1.envGate === "1",
+     "envGate reports \"1\" on state and pref-read after pref-set(true) (" + state1.envGate + "/" + read1.envGate + ")");
+  rmSync(dir, { recursive: true, force: true });
+}
+// An env holding something we never wrote (or nothing at all) is reported as null,
+// not passed through - the page must be able to tell "gate unset" from "gate off".
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-env-"));
+  const env = {};
+  const h = load(dir, env);
+  env.CDB_FILES_QUICK_OPEN = "yes";
+  const st = await h["cdb-qopen:state"](okSenderEv);
+  ok(st.envGate === null, "envGate is null when the variable holds a value we never wrote (" + st.envGate + ")");
+  delete env.CDB_FILES_QUICK_OPEN;
+  const st2 = await h["cdb-qopen:state"](okSenderEv);
+  ok(st2.envGate === null, "envGate is null when the variable is unset (" + st2.envGate + ")");
+  rmSync(dir, { recursive: true, force: true });
+}
+{
+  const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-main-env-"));
+  writeFileSync(join(dir, "claude-desktop-extra.json"), '{ "filesQuickOpen": true }\n');
+  const env = {};
+  load(dir, env);
+  ok(env.CDB_FILES_QUICK_OPEN === "1", "env mirror: \"1\" at load when the pref is already on");
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail ? 1 : 0);

--- a/scripts/tests/community/test-files-quick-open-worker.mjs
+++ b/scripts/tests/community/test-files-quick-open-worker.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/*
+ * test-files-quick-open-worker.mjs - the worker-side helper of the Files quick
+ * open feature (js/files_quick_open_worker.js, delivered into upstream's
+ * .vite/build/file-index-worker/fileIndexWorker.js by
+ * patches/community/add_feature_files_quick_open_worker.nim).
+ *
+ * Upstream's scorer walks the query char by char with indexOf, so a SPACE has to
+ * literally occur in the path: "user service" returned nothing (measured live
+ * 2026-08-29 on 1.37937.3). VS Code splits the query on spaces into pieces that
+ * must ALL match (fuzzyScorer.ts prepareQuery / doScoreItemFuzzyMultiple). The
+ * helper ports that on top of upstream's index without touching its scorer.
+ *
+ * Part A runs the helper against a FAKE index that reproduces upstream's
+ * contract: search(query, limit) -> [{path, score: rank/n, positions}], greedy
+ * subsequence, sorted best-first. Part B, when a compiled patch binary and an
+ * extracted worker bundle exist locally, patches a copy of the REAL worker and
+ * require()s it. Part B is reported as SKIP when either is missing.
+ *
+ * PART B SKIPS IN CI BY DESIGN. CI runs this harness from a clean checkout with
+ * no extracted bundle under tmp/ (the .deb is only unpacked inside the build
+ * job's own workspace), so there is nothing to patch and the block prints
+ * "SKIP real worker". That is not a coverage hole: in CI the guard against an
+ * upstream re-minify is the patch itself, which runs in the build and fails the
+ * whole job unless BOTH of its preconditions hold - the FileIndexHost.search
+ * call-site anchor (exactly one hit) and the scorer still destructuring
+ * `readyCount` off `this` (which the helper's full-set scan depends on; without
+ * it multi-piece queries would silently return nothing). Part B is the LOCAL
+ * end-to-end check: run it on a dev box with an extract under tmp/ (see
+ * ./scripts/build-local.sh) after any change to the helper or the patch.
+ */
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, existsSync, readdirSync, copyFileSync, accessSync, constants } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import vm from "node:vm";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+let pass = 0, fail = 0;
+const ok = (c, n) => { if (c) { pass++; console.log("  ok   " + n); } else { fail++; console.log("  FAIL " + n); } };
+const eq = (a, b, n) => ok(JSON.stringify(a) === JSON.stringify(b), n + (JSON.stringify(a) === JSON.stringify(b) ? "" : " -> got " + JSON.stringify(a)));
+const skip = (n, why) => console.log("  SKIP " + n + " -- " + why);
+
+// --- Part A: fake index with upstream's contract --------------------------------
+// Greedy leftmost subsequence on the path; fewer/shorter gaps rank higher.
+// Returns at most `limit`, best first, score = rank / n. Records calls so the
+// single-piece passthrough can be asserted. SMART CASE, like upstream's own
+// scorer (`let n = e !== e.toLowerCase(), r = n ? e : e.toLowerCase()` against
+// `paths` vs `lowerPaths`, 1.37937.3): a query carrying an uppercase character
+// is matched case-sensitively. The helper's ranking follows the same rule, so
+// the fake has to model it or the two would be asserted against each other.
+function fakeIndex(paths) {
+  const calls = [];
+  return {
+    calls,
+    readyCount: paths.length,
+    search(query, limit) {
+      calls.push([query, limit]);
+      if (limit <= 0) return [];
+      const cased = query !== query.toLowerCase();
+      const q = cased ? query : query.toLowerCase();
+      const hits = [];
+      for (const p of paths) {
+        const lp = cased ? p : p.toLowerCase(); const pos = []; let from = 0, gaps = 0;
+        let okAll = true;
+        for (const ch of q) { const i = lp.indexOf(ch, from); if (i < 0) { okAll = false; break; } if (pos.length && i > from) gaps += i - from; pos.push(i); from = i + 1; }
+        if (okAll) hits.push({ path: p, gaps, positions: pos });
+      }
+      hits.sort((a, b) => a.gaps - b.gaps || a.path.length - b.path.length);
+      const top = hits.slice(0, limit), n = Math.max(top.length, 1);
+      return top.map((h, i) => ({ path: h.path, score: i / n, positions: h.positions }));
+    }
+  };
+}
+
+function loadHelper(envValue) {
+  const src = readFileSync(join(ROOT, "js/files_quick_open_worker.js"), "utf8");
+  const sandbox = { process: { env: envValue === undefined ? {} : { CDB_FILES_QUICK_OPEN: envValue } }, console };
+  vm.runInNewContext(src + "\n;globalThis.__h = __cdbQoSearch;", vm.createContext(sandbox));
+  return sandbox.__h;
+}
+
+const PATHS = [
+  "modules/user/src/tests/user-run/use-cases/user-service.spec.ts",
+  "modules/user/src/domain/user-run/factories/user.service.ts",
+  "modules/support/src/core/data-provider/providers/abstract.pdf-data-provider.ts",
+  "shared/package.json",
+  "core/package.json",
+  "README.md"
+];
+const base = (r) => r.path.split("/").pop();
+// Upstream's scorer is a subsequence match over the WHOLE relative path, so
+// "user" also matches abstract.pdf-data-provider.ts across its directories
+// (u in support, s in src, e-r in data-provider), and "spec" aligns as s-p-e-c
+// over modules/support/src/core. An AND of pieces must admit those too;
+// membership is asserted order-insensitively because the merged rank depends on
+// upstream's per-piece scoring, not on us. Module scope: Part B uses them too.
+const BOTH = ["abstract.pdf-data-provider.ts", "user-service.spec.ts", "user.service.ts"];
+const SPEC = ["abstract.pdf-data-provider.ts", "user-service.spec.ts"];
+
+{
+  const h = loadHelper("1");
+  const idx = fakeIndex(PATHS);
+  eq(h(idx, "user service", 10).map(base).sort(), BOTH,
+     "two pieces: every path that is a subsequence match for BOTH pieces (upstream alone returned nothing)");
+  eq(h(idx, "service user", 10).map(base).sort(), BOTH,
+     "two pieces, REVERSED: same set - pieces are ANDed, not concatenated");
+  eq(h(idx, "user service spec", 10).map(base).sort(), SPEC,
+     "three pieces narrow to the paths matching all three (user.service.ts has no 'spec' subsequence)");
+  eq(h(idx, "shd pkg", 10).map(base), ["package.json"],
+     "abbreviated pieces: 'shd' + 'pkg' -> shared/package.json");
+  eq(h(idx, "zzz service", 10), [], "a piece that matches nothing empties the result (ALL pieces must match)");
+
+  const r = h(idx, "user service", 10)[0];
+  ok(r.positions.every((p, i) => i === 0 || p > r.positions[i - 1]), "positions are strictly ascending (unioned + deduped)");
+  ok(typeof r.score === "number" && r.score === 0, "score keeps upstream's rank/n shape (best hit = 0)");
+  const three = h(idx, "user service", 10);
+  ok(three.length === 3 && three[1].score === 1 / 3 && three[2].score === 2 / 3, "scores are rank/n over the merged set (1/3, 2/3)");
+  const one = h(idx, "user service", 1);
+  ok(one.length === 1 && BOTH.indexOf(base(one[0])) >= 0, "limit is honoured after the merge");
+  ok(idx.calls.length > 0 && idx.calls.every(([q, l]) => !/\s/.test(q)), "the index never sees a query containing whitespace");
+  ok(idx.calls.some(([q, l]) => l === PATHS.length), "per-piece scans ask for every ready path so the intersection is not lossy");
+}
+// --- ORDER: the file the query names, not its directories ------------------------
+// Measured live on 1.40609.0: the merge ordered by the SUMMED ORDINAL RANK of
+// upstream's per-piece scans, and an ordinal sum is not a score - a short path
+// that lands early in BOTH scans (a directory) beats the deep file the query
+// describes. A multi-word query returned three sibling directories above the
+// file it named. RANK_PATHS adds exactly that decoy: a path whose
+// BASENAME (x.ts) matches neither piece, qualifying only because both pieces are
+// subsequences of its DIRECTORIES. In this fake index it scores per-piece ranks
+// 0 and 0, so rank-sum ordering placed it FIRST of the four; the label-first
+// score places it last. The membership assertions above pin the SET; these pin
+// the ORDER, which is all this ranking may change.
+const RANK_PATHS = PATHS.concat(["src/user-service/types/x.ts"]);
+const RANK_BOTH = BOTH.concat(["x.ts"]).sort();
+{
+  const h = loadHelper("1");
+  const idx = fakeIndex(RANK_PATHS);
+  const two = h(idx, "user service", 10).map(base);
+  eq(two.slice(0, 2).sort(), ["user-service.spec.ts", "user.service.ts"],
+     "ranking: the two files NAMED user*service take the first two places (rank-sum put the decoy first)");
+  ok(two.indexOf("x.ts") > 1,
+     "ranking: a path whose basename matches NEITHER piece cannot outrank them: " + JSON.stringify(two));
+  eq(two.slice().sort(), RANK_BOTH, "ranking changes the ORDER only - the ANDed result set is unchanged");
+  eq(h(idx, "user service spec", 10).map(base)[0], "user-service.spec.ts",
+     "ranking: three pieces put the file whose NAME carries all three first");
+  eq(h(idx, "User service", 10).map(base).sort(), [],
+     "smart case is upstream's: an uppercase piece scans case-sensitively, so no all-lowercase path qualifies");
+}
+{
+  const h = loadHelper("1");
+  const idx = fakeIndex(PATHS);
+  const out = h(idx, "readme", 5);
+  eq(idx.calls, [["readme", 5]], "single piece: exactly one passthrough call with the caller's limit");
+  eq(out.map(base), ["README.md"], "single piece result is upstream's own");
+  idx.calls.length = 0;
+  h(idx, "  readme  ", 5);
+  eq(idx.calls, [["readme", 5]], "single piece with surrounding whitespace is trimmed (upstream would match a literal space)");
+}
+{
+  const h = loadHelper("0");
+  const idx = fakeIndex(PATHS);
+  eq(h(idx, "user service", 10), [], "env var \"0\": upstream behaviour untouched (space is a literal char -> no hits)");
+  eq(idx.calls, [["user service", 10]], "env var \"0\": the query is passed through verbatim");
+  const h2 = loadHelper(undefined);
+  const idx2 = fakeIndex(PATHS);
+  h2(idx2, "user service", 10);
+  eq(idx2.calls, [["user service", 10]], "env var unset: passthrough too (the feature is opt-in)");
+}
+{
+  const h = loadHelper("1");
+  const idx = fakeIndex(PATHS);
+  eq(h(idx, "", 3).length, idx.search("", 3).length, "empty query is delegated unchanged (upstream serves its top-level cache)");
+  // MAX_PIECES = 4: "a b c d e f" -> ["a", "b", "c", "def"], so exactly four
+  // per-piece scans and the tail folded into the last one. Asserting the CALLS
+  // (not just "<= 5 results", which an empty result would also satisfy) is what
+  // proves the fold happened rather than the query being dropped.
+  idx.calls.length = 0;
+  h(idx, "a b c d e f", 5);
+  eq(idx.calls.length, 4, "more than four pieces are folded into four scans");
+  eq(idx.calls.map(([q]) => q), ["a", "b", "c", "def"], "the tail pieces are concatenated into the last one");
+}
+
+// --- Part B: the REAL worker, patched by the compiled Nim binary ---------------------
+{
+  const bin = join(ROOT, "patches/community/add_feature_files_quick_open_worker");
+  // Newest versioned extract wins; a dir tagged STALE is never a candidate.
+  const candidates = existsSync(join(ROOT, "tmp")) ? readdirSync(join(ROOT, "tmp"))
+    .filter((d) => /^app\.asar\.contents(-\d+(\.\d+)*)?$/.test(d))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    .map((d) => join(ROOT, "tmp", d, ".vite/build/file-index-worker/fileIndexWorker.js"))
+    .filter((p) => existsSync(p)) : [];
+  let runnable = false;
+  try { accessSync(bin, constants.X_OK); runnable = candidates.length > 0; } catch {}
+  if (!runnable) {
+    skip("real worker", existsSync(bin) ? "no extracted worker under tmp/app.asar.contents*/" : "patch binary not compiled (cd patches && make)");
+  } else {
+    const dir = mkdtempSync(join(tmpdir(), "cdb-qopen-worker-"));
+    const copy = join(dir, "fileIndexWorker.js");
+    copyFileSync(candidates[candidates.length - 1], copy);
+    const out = execFileSync(bin, [copy], { encoding: "utf8" });
+    ok(/\[PASS\]|\[OK\]/.test(out) && !/\[FAIL\]/.test(out), "patch binary applies cleanly to the extracted worker: " + out.trim().split("\n").pop());
+    execFileSync("node", ["--check", copy]);
+    ok(true, "patched worker passes node --check");
+    process.env.CDB_FILES_QUICK_OPEN = "1";
+    const { FileIndexHost } = createRequire(import.meta.url)(copy);
+    const host = new FileIndexHost();
+    host.setEntries(PATHS.map((p) => ({ name: p.split("/").pop(), relativePath: p, fullPath: "/x/" + p, isDirectory: false })));
+    const realTwo = host.search("user service", 10).map((r) => r.relativePath.split("/").pop());
+    eq(realTwo.slice().sort(), BOTH, "REAL worker: 'user service' finds every path matching both pieces");
+    // FileIndexHost.search preserves the helper's order (`for(...of __cdbQoSearch(...))`
+    // pushing straight into its result array), so this is the ranking end to end.
+    eq(realTwo.slice(0, 2).sort(), ["user-service.spec.ts", "user.service.ts"],
+       "REAL worker: the two files NAMED user*service rank above the path that only matches 'user' across its directories");
+    eq(host.search("user service spec", 10).map((r) => r.relativePath.split("/").pop()).sort(), SPEC,
+       "REAL worker: 'user service spec' narrows to the paths matching all three pieces");
+    process.env.CDB_FILES_QUICK_OPEN = "0";
+    eq(host.search("user service", 10), [], "REAL worker: env \"0\" restores upstream's behaviour");
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail ? 1 : 0);

--- a/scripts/tests/core/test-extra-settings-dom.mjs
+++ b/scripts/tests/core/test-extra-settings-dom.mjs
@@ -297,6 +297,21 @@ async function featuresPanel(featuresItem) {
     ok(tabs.getAttribute("aria-checked") === "true", "the switch reflects the write");
   }
 
+  const qoSel = '.cdbx-switch[aria-label="open files with Ctrl+P from a quick-open box over the Files panel"]';
+  const qo = panel.querySelector(qoSel);
+  ok(!!qo, "renders the Files quick open switch");
+  if (qo) {
+    const qoRow = qo.closest(".cdbx-row");
+    ok(qoRow.querySelector(".cdbx-id").textContent === "Files quick open", "titled Files quick open");
+    ok(qo.getAttribute("aria-checked") === "false", "off by default (opt-in)");
+
+    qo.click();
+    await sleep(60);
+    ok(window.__quickOpenCalls.length === 1 && window.__quickOpenCalls[0] === true,
+       "clicking it calls quickOpenSet(true) exactly once: " + JSON.stringify(window.__quickOpenCalls));
+    ok(qo.getAttribute("aria-checked") === "true", "the switch reflects the write");
+  }
+
   const glow = panel.querySelector(".cdbx-switch[aria-label='calm the Cowork glow']");
   ok(!!glow, "the Cowork glow switch renders in the Community Features panel");
   if (glow) {
@@ -1179,6 +1194,8 @@ window.__deployCalls = [];
 window.__revealCalls = [];
 window.__panelTabsCalls = [];
 window.__panelTabsState = { ok: true, enabled: false, lockedByJsonc: false, source: "default" };
+window.__quickOpenCalls = [];
+window.__quickOpenState = { ok: true, enabled: false, lockedByJsonc: false, source: "default" };
 window.__diffViewsCalls = [];
 window.__diffViewsState = { ok: true, enabled: false, source: "default", defaultEnabled: false,
   lockedByJsonc: false, key: "diffViewModes" };
@@ -1280,6 +1297,8 @@ window.cdbExtra = {
     window.__panelTabsCalls.push(enabled);
     return Promise.resolve({ ok: true, enabled: enabled, path: "/tmp/panel-tabs.json" });
   },
+  quickOpenRead: function () { return Promise.resolve(window.__quickOpenState || { ok: true, enabled: false, lockedByJsonc: false, source: "default" }); },
+  quickOpenSet: function (enabled) { window.__quickOpenCalls = (window.__quickOpenCalls || []).concat([enabled]); return Promise.resolve({ ok: true, enabled: enabled }); },
   diffViewsRead: function () { return Promise.resolve(window.__diffViewsState); },
   diffViewsSet: function (enabled) {
     window.__diffViewsCalls.push(enabled);


### PR DESCRIPTION
Add a VS Code-style Ctrl+P quick open over the Code tab's Files panel — I kept reaching for it out of habit. Type part of a name, move with the arrow keys or the mouse, Enter opens the file as a tab; `:42` jumps to a line and an empty query lists recently opened files.

It also fixes the file search underneath: upstream treats a space as a literal character, so `payslip builder` matched nothing. Now spaces split the query into pieces that must all match in any order, ranked by file name like VS Code (`payslip builder` → `payslip-builder.spec.ts`) — the same fix reaches the Files panel's own filter and the composer's `@` picker.

Feature toggle in Settings → Extra → Community Features, off by default.

**Screenshots:**
<img width="1500" height="970" alt="1-modal" src="https://github.com/user-attachments/assets/9a52869d-b851-423b-99ce-3aff1dcebc88" />

<img width="1160" height="872" alt="2-settings" src="https://github.com/user-attachments/assets/b217bb25-79d7-488e-8e23-7c0a4dcd4b86" />
